### PR TITLE
[Attempt to Fix Unable to Add Tags For Newly Created User]

### DIFF
--- a/server/session.go
+++ b/server/session.go
@@ -536,7 +536,7 @@ func (s *Session) acc(msg *ClientComMessage) {
 
 		if msg.Acc.Tags != nil && len(msg.Acc.Tags) > 0 {
 			tags := make([]string, 0, len(msg.Acc.Tags))
-			if filterTags(tags, msg.Acc.Tags) > 0 {
+			if filterTags(&tags, msg.Acc.Tags) > 0 {
 				user.Tags = tags
 			}
 		}
@@ -832,7 +832,7 @@ func (s *Session) validateTopicName(msgId, topic string, timestamp time.Time) (s
 	return routeTo, nil
 }
 
-func filterTags(dst, src []string) int {
+func filterTags(dst *[]string, src []string) int {
 	if globals.indexableTags == nil || len(globals.indexableTags) == 0 {
 		return 0
 	}
@@ -848,11 +848,11 @@ func filterTags(dst, src []string) int {
 		parts[0] = strings.ToLower(parts[0])
 		for _, tag := range globals.indexableTags {
 			if parts[0] == tag {
-				dst = append(dst, parts[1])
+				*dst = append(*dst, s)
 			}
 		}
 	}
-	return len(dst)
+	return len(*dst)
 }
 
 func decodeAuthError(code int, id string, timestamp time.Time) *ServerComMessage {

--- a/server/topic.go
+++ b/server/topic.go
@@ -1162,7 +1162,7 @@ func (t *Topic) replySetDesc(sess *Session, set *MsgClientSet) error {
 			if set.Desc.Public != nil {
 				if src, ok := set.Desc.Public.([]string); ok && len(src) > 0 {
 					tags := make([]string, 0, len(src))
-					if filterTags(tags, src) > 0 {
+					if filterTags(&tags, src) > 0 {
 						// No need to send presence update
 						assignGenericValues(user, "Tags", tags)
 						t.public = tags


### PR DESCRIPTION
Hello, Gene

I found 2 bugs on `filterTags()` implementation which located on `session.go`:
- `dst` param should have type `*[]string` not `[]string`, the reason is because you intend to populate `dst` with filtered tags, so the param should pass by reference, not by value.
- the value should be appended to `dst` is `s` not `parts[1]`, so for example if `s` is `"email:someone@example.com"` then the value should be appended to `dst` is `"email:someone@example.com"` not `"someone@example.com"`.

The first bug will prevent new users to add tags to its account since the resulted filtered tags would always be empty.

The consequence of second bug is obvious I think.

Let me know your opinion.

Thanks.