### PR TITLE
[Attempt to Fix Unset P2P Permission for User in Other Side]

### DIFF
--- a/server/db/rethinkdb/adapter.go
+++ b/server/db/rethinkdb/adapter.go
@@ -249,7 +249,7 @@ func (a *RethinkDbAdapter) UpdAuthRecord(unique string, authLvl int, secret []by
 func (a *RethinkDbAdapter) GetAuthRecord(unique string) (t.Uid, int, []byte, time.Time, error) {
 	// Default() is needed to prevent Pluck from returning an error
 	rows, err := rdb.DB(a.dbName).Table("auth").Get(unique).Pluck(
-		"userid", "secret", "expires").Default(nil).Run(a.conn)
+		"userid", "secret", "expires", "authLvl").Default(nil).Run(a.conn)
 	if err != nil {
 		return t.ZeroUid, 0, nil, time.Time{}, err
 	}


### PR DESCRIPTION
Hello, Gene

I found bug on `GetAuthRecord()` implementation which located on `server/db/rethinkdb/adapter.go`: 
- it’s not fetching `authLvl` field from database.

The consequence of this bug is any authenticated user will treated as unauthenticated user (`authLvl` = `0`). 

When user want to create P2P topic with another user, this will cause the permission settings for other user left unsetted (`”N”`) which will cause other user unable to do anything with the topic due to insufficient permission.

So for example if there are 2 users: `user1` with `defacs: "JWRPS"` & `user2` with `defacs: "JWRPS"` which previously do not have P2P topic between each of them. Then `user1` create P2P topic to `user2`, this will create topic which has following permission: `user1` with`acs.mode:"JWRP"` & `user2` with `acs.mode:"N"`.

You could try this event on newly created empty database. On already populated database with sample data, I found that sometimes this event weirdly does not occurred.

You could see why this event occurred on `server/hub.go` at `line 484-491`. Since the value of `sreg.sess.authLvl` is equal to `0` (not equal to any of `auth.LevelAnon`, `auth.LevelAuth`, or `auth.LevelRoot`), then `sub2.ModeWant` would not be modified, hence the value for `sub2.ModeWant` would always be `”N”`.

Let me know your opinion.

Thanks.