### PR TITLE
[Attempt to Fix Incorrect Acc P2P Permission's Default Value]

### DIFF
--- a/server/session.go
+++ b/server/session.go
@@ -515,8 +515,8 @@ func (s *Session) acc(msg *ClientComMessage) {
 		var user types.User
 		var private interface{}
 		if msg.Acc.Desc != nil {
-			user.Access.Auth = getDefaultAccess(types.TopicCat_Me, true)
-			user.Access.Anon = getDefaultAccess(types.TopicCat_Me, false)
+			user.Access.Auth = getDefaultAccess(types.TopicCat_P2P, true)
+			user.Access.Anon = getDefaultAccess(types.TopicCat_P2P, false)
 
 			if msg.Acc.Desc.DefaultAcs != nil {
 				if msg.Acc.Desc.DefaultAcs.Auth != "" {


### PR DESCRIPTION
Hello, Gene

I found the bug. When creating the account, both `user.Access.Auth` & `user.Access.Anon` should have default access for `types.TopicCat_P2P` not `types.TopicCat_Me`.

The reason is because the `user.Access.Auth` & `user.Access.Anon` in this context is used for defining default access of current user to `P2P` topic not to `me` topic ([see here](https://github.com/tinode/chat/blob/master/API.md#acc)).

Let me know your opinion.

Thanks.