### PR TITLE
[Attempt to Fix Missing Value in {pres} Packet P2P]

### DIFF
--- a/server/topic.go
+++ b/server/topic.go
@@ -299,7 +299,11 @@ func (t *Topic) run(hub *Hub) {
 
 				pushRcpt = t.makePushReceipt(msg.Data)
 
-				t.presPubMessageSent(t.lastId)
+				var src = t.x_original
+				if t.cat == types.TopicCat_P2P {
+					src = msg.Data.From
+				}
+				t.presPubMessageSent(t.lastId, src)
 
 			} else if msg.Pres != nil {
 				// log.Printf("topic[%s].run: pres.src='%s' what='%s'", t.name, msg.Pres.Src, msg.Pres.With, msg.Pres.What)


### PR DESCRIPTION
Hello, Gene

I found bug on {pres} packet sent by server when current user is currently not subscribing to P2P topic but user in other side send message (use case 6): the `pres.src` value is always empty for P2P topic.

The cause of this bug is because in P2P topic, the `t.x_original` value is set to "" [(see here)](https://github.com/tinode/chat/blob/devel/server/hub.go#L543), but there is no assignment value when there is a message from user on the other side. Thus this situation lead into empty value of `pres.src`.

Let me know you opinion.

Thanks.