### PR TITLE
[Attempt to Ease Migration]

### DIFF
--- a/server/hub.go
+++ b/server/hub.go
@@ -524,6 +524,18 @@ func topicInit(sreg *sessionJoin, h *Hub) {
 					users[u2].Access.Auth,
 					types.ModeCP2P)
 			}
+            
+            // Make sure modeWant & modeGiven for both subscribers have 'A' permission on it
+            subs := []*types.Subscription{sub1, sub2}
+            for _, sub := range subs {
+                modes := []*types.AccessMode{&sub.ModeWant, &sub.ModeGiven}
+                for _, mode := range modes {
+                    (*mode) &= types.ModeCP2P
+                    if (*mode) != types.ModeNone {
+                        (*mode) |= types.ModeApprove
+                    }
+                }
+            }
 
 			// Create everything
 			if stopic == nil {


### PR DESCRIPTION
Hello, Gene

I would like to suggest adding safeguard for `‘A’` permission when user subscribing to `P2P` topic.

This will make our user which already installed previous version of Tinode able to migrate easily to current version without needing to upgrade their existing database which maybe already contains many users or `P2P` topics data. 

The difference between current permission model & previous one (from the data point of view) is only addition of `‘A’` permission in `P2P` topics. Yet this single permission could make such big difference in recent version. Thus in this attempt, I made sure that when user subscribing to `P2P` topic, the resulted mode would always contain `‘A’` permission unless the mode is `’N’`. If it doesn’t contain `‘A’` permission, then it means it comes from the old database, thus the server will update it.

Let me know your opinion.

Thanks
