### PR TITLE
[Attempt to Fix Uninitialized recvId & readId in P2P Topic Creation]

### DIFF
--- a/server/hub.go
+++ b/server/hub.go
@@ -402,7 +402,10 @@ func topicInit(sreg *sessionJoin, h *Hub) {
 					private:   subs[i].Private,
 					modeWant:  subs[i].ModeWant,
 					modeGiven: subs[i].ModeGiven,
-					clearId:   subs[i].ClearId}
+					clearId:   subs[i].ClearId,
+					recvId:    subs[i].RecvSeqId,
+					readId:    subs[i].ReadSeqId,
+				}
 			}
 
 		} else {


### PR DESCRIPTION
Hello, Gene

I found that on `P2P` topic creation `recvId` & `readId` attributes on `t.perUser` is not properly initialized. This will cause `readId` to become 0 when user initially only update `recvId` using `{note}`.

Let me know your opinion.

Thanks