### PR TITLE
[Attempt to Fix Stall Shutdown]

### DIFF
--- a/server/hub.go
+++ b/server/hub.go
@@ -78,6 +78,9 @@ type Hub struct {
 	// Request to shutdown, unbuffered
 	shutdown chan chan<- bool
 
+	// Flag for marking system shutdown is in progress
+	isShutdownInProgress bool
+
 	// Exported counter of live topics
 	topicsLive *expvar.Int
 }
@@ -203,6 +206,10 @@ func (h *Hub) run() {
 			}
 
 		case hubdone := <-h.shutdown:
+			// mark immediately to prevent more topics being added to hub.topics
+			h.isShutdownInProgress = true
+
+			// start cleanup process
 			topicsdone := make(chan bool)
 			for _, topic := range h.topics {
 				topic.exit <- &shutDown{done: topicsdone}
@@ -725,15 +732,18 @@ func topicInit(sreg *sessionJoin, h *Hub) {
 		return
 	}
 
-	log.Println("hub: topic created or loaded: " + t.name)
+	// only execute topic if shutdown is not in progress
+	if !h.isShutdownInProgress {
+		log.Println("hub: topic created or loaded: " + t.name)
 
-	h.topicPut(t.name, t)
-	h.topicsLive.Add(1)
-	go t.run(h)
+		h.topicPut(t.name, t)
+		h.topicsLive.Add(1)
+		go t.run(h)
 
-	sreg.loaded = true
-	// Topic will check access rights, send invite to p2p user, send {ctrl} message to the initiator session
-	t.reg <- sreg
+		sreg.loaded = true
+		// Topic will check access rights, send invite to p2p user, send {ctrl} message to the initiator session
+		t.reg <- sreg
+	}
 }
 
 // loadSubscribers loads topic subscribers, sets topic owner


### PR DESCRIPTION
Hello, Gene

I found problem when shutting down system while it being hit by high traffic. It's stall, unable to finish the cleanup for topics. 

The issue is triggered by these lines: https://github.com/tinode/chat/blob/devel/server/hub.go#L207-L213. 

Notice that when we issue shutdown, apparently we didn't stop the hub for putting more topics to `hub.topics` (because we use goroutine to run `topicInit()`). So the result of `len(h.topics)` on [line 207](https://github.com/tinode/chat/blob/devel/server/hub.go#L207) could be different from the result of `len(h.topics)` on [line 211](https://github.com/tinode/chat/blob/devel/server/hub.go#L211). 

It is often that the result of `line 211` is greater than the result of `line 207` which then caused stall because `<-topicsdone` is always blocking.

So to overcome this issue, I suggest we prevent put operation on `hub.topics` when system shutdown is in progress.

Let me know your opinion.

Thanks