### PR TITLE
[Attempt to Terminate All Topics Cleanly While Shutdown]

### DIFF
--- a/server/hub.go
+++ b/server/hub.go
@@ -752,6 +752,11 @@ func topicInit(sreg *sessionJoin, h *Hub) {
 		return
 	}
 
+	// prevent newly initialized topics to live while shutdown in progress
+	if h.isShutdownInProgress {
+		return
+	}
+
 	log.Println("hub: topic created or loaded: " + t.name)
 
 	h.topicPut(t.name, t)


### PR DESCRIPTION
Hmmm..., I'm thinking maybe we should add checking to `h.isShutdownInProgress()` in the end of `topicInit()` as well. It's probably cleaner in terms of terminating all topics completely.

The reason is, there is still a chance that new topics would be added to `hub.topics` after call to `h.topics.Range()` is done. Even though the system won't stall because we use `topicCount` when iterating `<-topicsdone`, but the newly added topics would not be terminated cleanly, right?

But if we prevent these newly added topics from being added to `hub.topics` from the very beginning, then we could guarantee there are no additional topics being added to `hub.topics`. Hence we could make sure that all topics in `hub.topics` terminated cleanly.

What do you think?