### PR TITLE
Fix Params Null in Response of {hi}

### DIFF
--- a/server/session.go
+++ b/server/session.go
@@ -426,12 +426,12 @@ func (s *Session) hello(msg *ClientComMessage) {
 		httpStatus = http.StatusCreated
 		httpStatusText = "created"
 	}
-	s.queueOut(&ServerComMessage{Ctrl: &MsgServerCtrl{
-		Id:        msg.Hi.Id,
-		Code:      httpStatus,
-		Text:      httpStatusText,
-		Params:    params,
-		Timestamp: msg.timestamp}})
+
+	ctrl := &MsgServerCtrl{Id: msg.Hi.Id, Code: httpStatus, Text: httpStatusText, Timestamp: msg.timestamp}
+	if len(params) > 0 {
+		ctrl.Params = params
+	}
+	s.queueOut(&ServerComMessage{Ctrl: ctrl})
 }
 
 // Authenticate

--- a/server/session.go
+++ b/server/session.go
@@ -427,6 +427,7 @@ func (s *Session) hello(msg *ClientComMessage) {
 		httpStatusText = "created"
 	}
 
+	// fix null printed value in params
 	ctrl := &MsgServerCtrl{Id: msg.Hi.Id, Code: httpStatus, Text: httpStatusText, Timestamp: msg.timestamp}
 	if len(params) > 0 {
 		ctrl.Params = params


### PR DESCRIPTION
Hello, Gene

I found glitch in `{hi}` response. The field `"params"` would be still printed even if it has zero value.

For details you could take a look at this snippet which demonstrate this issue: https://play.golang.org/p/lJiwbC8Ebg

Let me know your opinion.

Thanks