### PR TITLE
Add ENV variable to also reset database

### DIFF
--- a/docker/tinode/Dockerfile
+++ b/docker/tinode/Dockerfile
@@ -33,7 +33,7 @@ ENV API_KEY_SALT=T713/rYYgW7g4m3vG6zGRh7+FM1t0T8j13koXScOAj4=
 # Key used to sign authentication tokens.
 ENV AUTH_TOKEN_KEY=wfaY2RgF2S1OQI/ZlK+LSrp1KB2jwAdGAIHQ7JZn+Kc=
 
-# Disable chatbot plugin by default. 
+# Disable chatbot plugin by default.
 ENV PLUGIN_PYTHON_CHAT_BOT_ENABLED=false
 
 # Adding bash and grep as they are used here.
@@ -57,9 +57,10 @@ RUN mkdir /botdata
 RUN chmod +x entrypoint.sh
 RUN chmod +x credentials.sh
 
+ENV RESET_DB=false
+
 # Generate config from template and run the server.
 ENTRYPOINT ./entrypoint.sh
 
 # HTTP and gRPC ports
 EXPOSE 18080 16061
-

--- a/docker/tinode/entrypoint.sh
+++ b/docker/tinode/entrypoint.sh
@@ -15,11 +15,11 @@ done < config.template
 
 
 # Initialize the database if it has not been initialized yet
-if [ ! -f /botdata/.tn-cookie ]; then
+if [ ! -f /botdata/.tn-cookie ] || [ $RESET_DB ] ; then
 	# Run the generator. Save stdout to to a file to extract Tino's password for possible later use.
 	./init-db --reset --config=working.config --data=data.json | grep "usr;tino;" > /botdata/tino-password
 
-	# Convert Tino's authentication credentials into a cookie file. 
+	# Convert Tino's authentication credentials into a cookie file.
 	# The cookie file is also used to check if database has been initialized.
 	./credentials.sh < /botdata/tino-password > /botdata/.tn-cookie
 fi


### PR DESCRIPTION
The ability to reset the DB via a run arg would be useful, so I added it quickly. In the future I'll also need to be able to pass database information via docker env as well, so I'll eventually pull request that as well.