### PR TITLE
CMD instead of ENTRYPOINT

### DIFF
--- a/docker/chatbot/Dockerfile
+++ b/docker/chatbot/Dockerfile
@@ -24,7 +24,7 @@ RUN tar -xzf chatbot.tar.gz \
 
 # Use command line parameter `-e LOGIN_AS=user:password` to login as someone other than Tino.
 
-ENTRYPOINT python chatbot.py --login-basic=${LOGIN_AS} --login-cookie=/botdata/.tn-cookie --host=tinode-srv:16061 > /var/log/chatbot.log
+CMD python chatbot.py --login-basic=${LOGIN_AS} --login-cookie=/botdata/.tn-cookie --host=tinode-srv:16061 > /var/log/chatbot.log
 
 # Plugin port
 EXPOSE 40051


### PR DESCRIPTION
:man: :bear: :pig: 

Let's make it easier to run `docker run` without having to flag `--entrypoint` to override the entry point.