### PR TITLE
Allow disabling Android notifications in FCM push messages

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -100,6 +100,7 @@ You can specify the following environment variables when issuing `docker run` co
 | `FCM_CRED_FILE` | string |  | Path to json file with FCM server-side service account credentials which will be used to send push notifications. |
 | `FCM_SENDER_ID` | string |  | FCM sender ID for receiving push notifications in the web client |
 | `FCM_VAPID_KEY` | string |  | Also called 'Web Client certificate' in the FCM console. Required by the web client to receive push notifications. |
+| `FCM_PUSH_INCLUDE_ANDROID_NOTIFICATION` | boolean | true | If true, pushes a data + notification message, otherwise a data-only message. [More info](https://firebase.google.com/docs/cloud-messaging/concept-options). |
 | `MEDIA_HANDLER` | string | `fs` | Handler of large files, either `fs` or `s3` |
 | `MYSQL_DSN` | string | `'root@tcp(mysql)/tinode'` | MySQL [DSN](https://github.com/go-sql-driver/mysql#dsn-data-source-name). |
 | `PLUGIN_PYTHON_CHAT_BOT_ENABLED` | bool | `false` | Enable calling into the plugin provided by Python chatbot | 

--- a/docker/tinode/Dockerfile
+++ b/docker/tinode/Dockerfile
@@ -63,6 +63,9 @@ ENV TLS_ENABLED=false
 # Disable push notifications by default.
 ENV FCM_PUSH_ENABLED=false
 
+# Enable Android-specific notifications by default.
+ENV FCM_PUSH_INCLUDE_ANDROID_NOTIFICATION=true
+
 # Install root certificates. Needed for email validator to work
 # with the TLS SMTP servers like Gmail.
 RUN apk update && apk add --no-cache ca-certificates

--- a/docker/tinode/config.template
+++ b/docker/tinode/config.template
@@ -103,6 +103,7 @@
 				"project_id": "$FCM_PROJECT_ID",
 				"credentials_file": "$FCM_CRED_FILE",
 				"time_to_live": 3600,
+				"include_android_notification": $FCM_PUSH_INCLUDE_ANDROID_NOTIFICATION,
 				"icon": "ic_logo_push",
 				"icon_color": "#3949AB"
 			}

--- a/server/push/fcm/push_fcm.go
+++ b/server/push/fcm/push_fcm.go
@@ -33,13 +33,14 @@ type Handler struct {
 }
 
 type configType struct {
-	Enabled         bool            `json:"enabled"`
-	Buffer          int             `json:"buffer"`
-	Credentials     json.RawMessage `json:"credentials"`
-	CredentialsFile string          `json:"credentials_file"`
-	TimeToLive      uint            `json:"time_to_live,omitempty"`
-	Icon            string          `json:"icon,omitempty"`
-	IconColor       string          `json:"icon_color,omitempty"`
+	Enabled                    bool            `json:"enabled"`
+	Buffer                     int             `json:"buffer"`
+	Credentials                json.RawMessage `json:"credentials"`
+	CredentialsFile            string          `json:"credentials_file"`
+	TimeToLive                 uint            `json:"time_to_live,omitempty"`
+	IncludeAndroidNotification bool            `json:"include_android_notification,omitempty"`
+	Icon                       string          `json:"icon,omitempty"`
+	IconColor                  string          `json:"icon_color,omitempty"`
 }
 
 // Init initializes the push handler
@@ -167,12 +168,15 @@ func sendNotifications(rcpt *push.Receipt, config *configType) {
 				}
 				if d.Platform == "android" {
 					msg.Android = &fcm.AndroidConfig{
-						Notification: &fcm.AndroidNotification{
+						Priority: "high",
+					}
+					if config.IncludeAndroidNotification {
+						msg.Android.Notification = &fcm.AndroidNotification{
 							Title: "New message",
 							Body:  data["content"],
 							Icon:  config.Icon,
 							Color: config.IconColor,
-						},
+						}
 					}
 				}
 

--- a/server/tinode.conf
+++ b/server/tinode.conf
@@ -259,6 +259,9 @@
 				// Time in seconds before notification is discarded if undelivered (by Google).
 				"time_to_live": 3600,
 
+				// Include Android Notification. Set to false to push a data-only message.
+				"include_android_notification": true,
+
 				// Android resource ID to use as a notification icon.
 				"icon": "ic_logo_push",
 


### PR DESCRIPTION
As discussed at: https://groups.google.com/forum/#!topic/tinode/KRQBB1r1OYk

This PR allows disabling the "Notification" payload for FCM push messages to Android. 

Motivation: Notification push messages are handled by the OS directly without any intervention by the mobile app. It's thus not possible to alter the notification such as using the sender's name or marking the message immediately as received.

Backwards compatibility was kept. The default continues to be that push messages are "data + notification".

