### PR TITLE
In Docker image, send tinode output to stdout.

### DIFF
--- a/docker/tinode/Dockerfile
+++ b/docker/tinode/Dockerfile
@@ -11,7 +11,7 @@
 
 FROM alpine:latest
 
-ARG VERSION=0.15
+ARG VERSION=0.16.1
 ENV VERSION=$VERSION
 
 LABEL maintainer="Gene Sokolov <gene@tinode.co>"

--- a/docker/tinode/entrypoint.sh
+++ b/docker/tinode/entrypoint.sh
@@ -56,7 +56,8 @@ else
 fi
 
 # Initialize the database if it has not been initialized yet or if data reset/upgrade has been requested.
-./init-db --reset=${RESET_DB} --upgrade=${UPGRADE_DB} --config=${CONFIG} --data=${SAMPLE_DATA} | grep "usr;tino;" > /botdata/tino-password
+./init-db --reset=${RESET_DB} --upgrade=${UPGRADE_DB} --config=${CONFIG} --data=${SAMPLE_DATA} 2>&1 > /var/log/tinode-init-db.log
+grep "usr;tino;" /var/log/tinode-init-db.log > /botdata/tino-password
 
 if [ -s /botdata/tino-password ] ; then
 	# Convert Tino's authentication credentials into a cookie file.
@@ -68,4 +69,4 @@ if [ -s /botdata/tino-password ] ; then
 fi
 
 # Run the tinode server.
-./tinode --config=${CONFIG} --static_data=static 2> /var/log/tinode.log
+./tinode --config=${CONFIG} --static_data=static 2>&1

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,18 +1,15 @@
 # Frequently Asked Questions
 
 ### Q: Where can I find server logs when running in Docker?<br/>
-**A**: The log is in the container at `/var/log/tinode.log`. Attach to a running container with command
+**A**: The logs are written to container's stdout. To view the logs, run
 ```
-docker exec -it name-of-the-running-container /bin/bash
-```
-Then, for instance, see the log with `tail -50 /var/log/tinode.log`
-
-If the container has stopped already, you can copy the log out of the container (saving it to `./tinode.log`):
-```
-docker cp name-of-the-container:/var/log/tinode.log ./tinode.log
+docker logs name-of-the-running-container
 ```
 
-Alternatively, you can instruct the docker container to save the logs to a directory on the host by mapping a host directory to `/var/log/` in the container. Add `-v /where/to/save/logs:/var/log` to the `docker run` command.
+Alternatively, you can access the log file on the host machine at
+```
+/var/lib/docker/containers/<container id>/<container id>-json.log
+```
 
 ### Q: How to setup FCM push notifications?<br/>
 **A**: If you running the server directly:


### PR DESCRIPTION
It's pretty straightforward to get the bot password.
So there's no need to create another Docker image at this point.