### PR TITLE
Clustering support for user cache

### DIFF
--- a/server/cluster.go
+++ b/server/cluster.go
@@ -379,6 +379,24 @@ func (c *Cluster) Route(msg *ClusterReq, rejected *bool) error {
 	return nil
 }
 
+// User cache & push notifications management. These are calls received by the Master from Proxy.
+// The Proxy expects no payload to be returned by the master.
+
+// UserUpdate endpoint updates user's cached values.
+func (c *Cluster) UserUpdate(req *UserCacheReq, rejected *bool) error {
+	return nil
+}
+
+// UserPush endpoint processes requests to send push notifications.
+func (c *Cluster) UserPush(req *UserCacheReq, rejected *bool) error {
+	return nil
+}
+
+// Sends user cahce update to user's master node
+func (c *Cluster) routeUserReq(req *UserCacheReq) error {
+	return nil
+}
+
 // Given topic name, find appropriate cluster node to route message to
 func (c *Cluster) nodeForTopic(topic string) *ClusterNode {
 	key := c.ring.Get(topic)
@@ -415,7 +433,7 @@ func (c *Cluster) isPartitioned() bool {
 	return (len(c.nodes)+1)/2 >= len(c.fo.activeNodes)
 }
 
-// Forward client message to the Master (cluster node which owns the topic)
+// Forward client request message to the Master (cluster node which owns the topic)
 func (c *Cluster) routeToTopic(msg *ClientComMessage, topic string, sess *Session) error {
 	// Find the cluster node which owns the topic, then forward to it.
 	n := c.nodeForTopic(topic)
@@ -455,7 +473,7 @@ func (c *Cluster) routeToTopic(msg *ClientComMessage, topic string, sess *Sessio
 
 }
 
-// Forward server message to the node that owns topic.
+// Forward server response message to the node that owns topic.
 func (c *Cluster) routeToTopicIntraCluster(topic string, msg *ServerComMessage) error {
 	n := c.nodeForTopic(topic)
 	if n == nil {

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -397,7 +397,7 @@ func (c *Cluster) routeUserReq(req *UserCacheReq) error {
 	reqByNode := make(map[string]*UserCacheReq)
 
 	if req.PushRcpt != nil {
-		// Request to send push notifications. Cretae separate packets for each affected cluster node.
+		// Request to send push notifications. Create separate packets for each affected cluster node.
 		for uid, recepient := range req.PushRcpt.To {
 			n := c.nodeForTopic(uid.UserId())
 			if n == nil {

--- a/server/cluster_leader.go
+++ b/server/cluster_leader.go
@@ -236,7 +236,7 @@ func (c *Cluster) electLeader() {
 	if voteCount >= expectVotes {
 		// Current node elected as the leader
 		c.fo.leader = c.thisNodeName
-		log.Println("Elected myself as a new leader")
+		log.Printf("'%s' elected self as a new leader", c.thisNodeName)
 	}
 }
 

--- a/server/http.go
+++ b/server/http.go
@@ -29,7 +29,7 @@ import (
 )
 
 func listenAndServe(addr string, mux *http.ServeMux, tlfConf *tls.Config, stop <-chan bool) error {
-	shuttingDown := false
+	globals.shuttingDown = false
 
 	httpdone := make(chan bool)
 
@@ -64,7 +64,7 @@ func listenAndServe(addr string, mux *http.ServeMux, tlfConf *tls.Config, stop <
 			err = server.ListenAndServe()
 		}
 		if err != nil {
-			if shuttingDown {
+			if globals.shuttingDown {
 				log.Println("HTTP server: stopped")
 			} else {
 				log.Println("HTTP server: failed", err)
@@ -79,7 +79,7 @@ Loop:
 		select {
 		case <-stop:
 			// Flip the flag that we are terminating and close the Accept-ing socket, so no new connections are possible.
-			shuttingDown = true
+			globals.shuttingDown = true
 			// Give server 2 seconds to shut down.
 			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 			if err := server.Shutdown(ctx); err != nil {

--- a/server/hub.go
+++ b/server/hub.go
@@ -103,9 +103,6 @@ type Hub struct {
 
 	// Request to shutdown, unbuffered
 	shutdown chan chan<- bool
-
-	// Flag for indicating that system shutdown is in progress
-	isShutdownInProgress bool
 }
 
 func (h *Hub) topicGet(name string) *Topic {
@@ -262,9 +259,6 @@ func (h *Hub) run() {
 			})
 
 		case hubdone := <-h.shutdown:
-			// mark immediately to prevent more topics being added to hub.topics
-			h.isShutdownInProgress = true
-
 			// start cleanup process
 			topicsdone := make(chan bool)
 			topicCount := 0

--- a/server/init_topic.go
+++ b/server/init_topic.go
@@ -82,7 +82,7 @@ func topicInit(t *Topic, sreg *sessionJoin, h *Hub) {
 	}
 
 	// prevent newly initialized topics to go live while shutdown in progress
-	if h.isShutdownInProgress {
+	if globals.shuttingDown {
 		h.topicDel(sreg.topic)
 		return
 	}

--- a/server/main.go
+++ b/server/main.go
@@ -112,6 +112,8 @@ type credValidator struct {
 var globals struct {
 	// Topics cache and processing.
 	hub *Hub
+	// Indicator that shutdown is in progress
+	shuttingDown bool
 	// Sessions cache.
 	sessionStore *SessionStore
 	// Cluster data.

--- a/server/main.go
+++ b/server/main.go
@@ -123,7 +123,7 @@ var globals struct {
 	// Runtime statistics communication channel.
 	statsUpdate chan *varUpdate
 	// Users cache communication channel.
-	usersUpdate chan *userUpdate
+	usersUpdate chan *UserCacheReq
 
 	// Credential validators.
 	validators map[string]credValidator

--- a/server/run-cluster.sh
+++ b/server/run-cluster.sh
@@ -3,36 +3,48 @@
 # Start/stop test cluster on localhost. This is NOT a production script. Use it for reference only.
 
 # Names of cluster nodes
-node_names=( one two three )
+ALL_NODE_NAMES=( one two three )
 # Port where the first node will listen for client connections over http
-base_http_port=6080
-# Port where the first node will listen for gRPC connections.
-base_grpc_port=6090
+HTTP_BASE_PORT=6080
+# Port where the first node will listen for gRPC intra-cluster connections.
+GRPC_BASE_PORT=6090
+
+# Allow for non-default config file to be specifid on the command line like config=file_name
+if [ ! -z "$CONFIG" ] ; then
+  TINODE_CONF=$CONFIG
+else
+  TINODE_CONF="./tinode.conf"
+fi
 
 case "$1" in
   start)
     echo 'Running cluster on localhost, ports 6080-6082'
 
-    http_port=$base_http_port
-    grpc_port=$base_grpc_port
-    for node_name in "${node_names[@]}"
+    HTTP_PORT=$HTTP_BASE_PORT
+    GRPC_PORT=$GRPC_BASE_PORT
+    for NODE_NAME in "${ALL_NODE_NAMES[@]}"
     do
-      ./server -config=./tinode.conf -cluster_self=$node_name -listen=:${http_port} -grpc_listen=:${grpc_port} &
-      # /var/tmp/ does not requre root access
-      echo $!> "/var/tmp/tinode-${node_name}.pid"
-      http_port=$((http_port+1))
-      grpc_port=$((grpc_port+1))
+      # Start the node
+      ./server -config=${TINODE_CONF} -cluster_self=$NODE_NAME -listen=:${HTTP_PORT} -grpc_listen=:${GRPC_PORT} &
+      # Save PID of the node to a temp file.
+      # /var/tmp/ does not requre root access.
+      echo $!> "/var/tmp/tinode-${NODE_NAME}.pid"
+      # Increment ports for the next node.
+      HTTP_PORT=$((HTTP_PORT+1))
+      GRPC_PORT=$((GRPC_PORT+1))
     done
     ;;
   stop)
     echo 'Stopping cluster'
 
-    for node_name in "${node_names[@]}"
+    for NODE_NAME in "${ALL_NODE_NAMES[@]}"
     do
-      kill `cat /var/tmp/tinode-${node_name}.pid`
-      rm "/var/tmp/tinode-${node_name}.pid"
+      # Reda PIDs of running nodes from temp files and kill them.
+      kill `cat /var/tmp/tinode-${NODE_NAME}.pid`
+      # Clean up: delete temp files.
+      rm "/var/tmp/tinode-${NODE_NAME}.pid"
     done
     ;;
   *)
-    echo $"Usage: $0 {start|stop}"
+    echo $"Usage: $0 {start|stop} [config=./tinode.conf]"
 esac

--- a/server/run-cluster.sh
+++ b/server/run-cluster.sh
@@ -10,8 +10,8 @@ HTTP_BASE_PORT=6080
 GRPC_BASE_PORT=6090
 
 # Allow for non-default config file to be specifid on the command line like config=file_name
-if [ ! -z "$CONFIG" ] ; then
-  TINODE_CONF=$CONFIG
+if [ ! -z "$config" ] ; then
+  TINODE_CONF=$config
 else
   TINODE_CONF="./tinode.conf"
 fi
@@ -46,5 +46,5 @@ case "$1" in
     done
     ;;
   *)
-    echo $"Usage: $0 {start|stop} [config=./tinode.conf]"
+    echo $"Usage: $0 {start|stop} [ config=<path_to_tinode.conf> ]"
 esac

--- a/server/store/types/types.go
+++ b/server/store/types/types.go
@@ -81,9 +81,9 @@ func (uid Uid) Compare(u2 Uid) int {
 }
 
 // MarshalBinary converts Uid to byte slice.
-func (uid *Uid) MarshalBinary() ([]byte, error) {
+func (uid Uid) MarshalBinary() ([]byte, error) {
 	dst := make([]byte, 8)
-	binary.LittleEndian.PutUint64(dst, uint64(*uid))
+	binary.LittleEndian.PutUint64(dst, uint64(uid))
 	return dst, nil
 }
 

--- a/server/user.go
+++ b/server/user.go
@@ -530,6 +530,9 @@ func replyDelUser(s *Session, msg *ClientComMessage) {
 
 // UserCacheReq contains data which mutates one or more user cache entries.
 type UserCacheReq struct {
+	// Name of the node sending this request in case of cluster. Not set otherwise.
+	Node string
+
 	// UserId is set when a single user is updated.
 	UserId types.Uid
 	// UserIdList  is set when multiple users are updated.

--- a/server/user.go
+++ b/server/user.go
@@ -595,7 +595,7 @@ func usersPush(rcpt *push.Receipt) {
 	var local *UserCacheReq
 
 	// In case of a cluster pushes will be initiated at the nodes which own the users.
-	// Sort users into loacl and remote.
+	// Sort users into local and remote.
 	if globals.cluster != nil {
 		local = &UserCacheReq{PushRcpt: &push.Receipt{
 			Payload: rcpt.Payload,

--- a/server/user.go
+++ b/server/user.go
@@ -728,6 +728,12 @@ func userUpdater() {
 	}
 
 	for upd := range globals.usersUpdate {
+		if globals.shuttingDown {
+			// If shutdown is in progress we don't care to process anything.
+			// ignore all calls.
+			continue
+		}
+
 		// Shutdown requested.
 		if upd == nil {
 			globals.usersUpdate = nil
@@ -745,6 +751,7 @@ func userUpdater() {
 					upd.PushRcpt.To[uid] = rcptTo
 				}
 			}
+
 			push.Push(upd.PushRcpt)
 			continue
 		}
@@ -771,7 +778,7 @@ func userUpdater() {
 					}
 				} else {
 					// BUG!
-					log.Println("ERROR: request to unregister user which has not been registered")
+					log.Println("ERROR: request to unregister user which has not been registered", uid)
 				}
 			}
 


### PR DESCRIPTION
User cache is needed for iOS badge with the count of unread messages. It was implemented without regard for clustering. This PR adds clustering support to user cache. 