### PR TITLE
Send {pres term} to displaced topic subs

### DIFF
--- a/server/cluster.go
+++ b/server/cluster.go
@@ -504,8 +504,7 @@ func (c *Cluster) isRemoteTopicExpanded(topic string, nodeName *string) bool {
 		// Cluster not initialized, all topics are local
 		return false
 	}
-	var remoteNode string
-	remoteNode = c.ring.Get(topic)
+	remoteNode := c.ring.Get(topic)
 	if nodeName != nil {
 		*nodeName = remoteNode
 	}

--- a/server/cluster_leader.go
+++ b/server/cluster_leader.go
@@ -179,6 +179,7 @@ func (c *Cluster) sendPings() {
 
 		c.fo.activeNodes = activeNodes
 		c.rehash(activeNodes)
+		c.invalidateRemoteSubs(globals.sessionStore)
 
 		log.Println("cluster: initiating failover rehash for nodes", activeNodes)
 		globals.hub.rehash <- true
@@ -301,6 +302,7 @@ func (c *Cluster) run() {
 					log.Println("cluster: rehashing at a request of",
 						ping.Leader, ping.Nodes, ping.Signature, c.ring.Signature())
 					c.rehash(ping.Nodes)
+					c.invalidateRemoteSubs(globals.sessionStore)
 					rehashSkipped = false
 
 					globals.hub.rehash <- true

--- a/server/pres.go
+++ b/server/pres.go
@@ -295,6 +295,17 @@ func (t *Topic) presSubsOnlineDirect(what string) {
 	}
 }
 
+// Communicate "topic unaccessible (cluster rehashing or node connection lost)" event
+// for a list of topics promting the client to resubscribe to the topics.
+func (s *Session) presTermDirect(subs []string) {
+	log.Printf("sid '%s', uid '%s', terminating %s", s.sid, s.uid, subs)
+	msg := &ServerComMessage{Pres: &MsgServerPres{Topic: "me", What: "term"}}
+	for _, topic := range subs {
+		msg.Pres.Src = topic
+		s.queueOut(msg)
+	}
+}
+
 // Publish to topic subscribers's sessions currently offline in the topic, on their 'me'
 // Group and P2P.
 // Case E: topic came online, "on"

--- a/server/session.go
+++ b/server/session.go
@@ -39,6 +39,14 @@ const sendTimeout = time.Microsecond * 150
 
 var minSupportedVersionValue = parseVersion(minSupportedVersion)
 
+// Holds metadata on the subscription/topic hosted on a remote node.
+type RemoteSubscription struct {
+	// Hosting node.
+	node string
+	// Topic name, as specified by the client.
+	originalTopic string
+}
+
 // Session represents a single WS connection or a long polling session. A user may have multiple
 // sessions.
 type Session struct {
@@ -99,9 +107,16 @@ type Session struct {
 	// Map of topic subscriptions, indexed by topic name.
 	// Don't access directly. Use getters/setters.
 	subs map[string]*Subscription
+
 	// Mutex for subs access: both topic go routines and network go routines access
 	// subs concurrently.
 	subsLock sync.RWMutex
+
+	// Map of remote topic subscriptions, indexed by topic name.
+	remoteSubs map[string]*RemoteSubscription
+
+	// Synchronizes access to remoteSubs.
+	remoteSubsLock sync.RWMutex
 
 	// Cluster nodes to inform when the session is disconnected
 	nodes map[string]bool
@@ -160,6 +175,20 @@ func (s *Session) unsubAll() {
 		// sub.done is the same as topic.unreg
 		sub.done <- &sessionLeave{sess: s}
 	}
+}
+
+func (s *Session) addRemoteSub(topic string, remoteSub *RemoteSubscription) {
+	s.remoteSubsLock.Lock()
+	defer s.remoteSubsLock.Unlock()
+
+	s.remoteSubs[topic] = remoteSub
+}
+
+func (s *Session) delRemoteSub(topic string) {
+	s.remoteSubsLock.Lock()
+	defer s.remoteSubsLock.Unlock()
+
+	delete(s.remoteSubs, topic)
 }
 
 // queueOut attempts to send a ServerComMessage to a session; if the send buffer is full,
@@ -374,13 +403,16 @@ func (s *Session) subscribe(msg *ClientComMessage) {
 		}
 	}
 
+	var remoteNodeName string
 	if sub := s.getSub(expanded); sub != nil {
 		s.queueOut(InfoAlreadySubscribed(msg.id, msg.topic, msg.timestamp))
-	} else if globals.cluster.isRemoteTopic(expanded) {
+	} else if globals.cluster.isRemoteTopicExpanded(expanded, &remoteNodeName) {
 		// The topic is handled by a remote node. Forward message to it.
 		if err := globals.cluster.routeToTopic(msg, expanded, s); err != nil {
 			log.Println("s.subscribe:", err, s.sid)
 			s.queueOut(ErrClusterUnreachable(msg.id, msg.topic, msg.timestamp))
+		} else {
+			s.addRemoteSub(expanded, &RemoteSubscription{node: remoteNodeName, originalTopic: msg.topic})
 		}
 	} else {
 		globals.hub.join <- &sessionJoin{
@@ -420,6 +452,8 @@ func (s *Session) leave(msg *ClientComMessage) {
 		if err := globals.cluster.routeToTopic(msg, expanded, s); err != nil {
 			log.Println("s.leave:", err, s.sid)
 			s.queueOut(ErrClusterUnreachable(msg.id, msg.topic, msg.timestamp))
+		} else {
+			s.delRemoteSub(expanded)
 		}
 	} else if !msg.Leave.Unsub {
 		// Session is not attached to the topic, wants to leave - fine, no change

--- a/server/sessionstore.go
+++ b/server/sessionstore.go
@@ -63,6 +63,7 @@ func (ss *SessionStore) NewSession(conn interface{}, sid string) (*Session, int)
 		s.send = make(chan interface{}, 256) // buffered
 		s.stop = make(chan interface{}, 1)   // Buffered by 1 just to make it non-blocking
 		s.detach = make(chan string, 64)     // buffered
+		s.remoteSubs = make(map[string]*RemoteSubscription)
 	}
 
 	s.lastTouched = time.Now()


### PR DESCRIPTION
Keep a list of remote subscriptions in sessions.
After rehashing takes place, for each session walk over the list of its remote
topic subscriptions and send {pres term} to those whose hosting nodes have changed.