### PR TITLE
Remove label from version metric in promexp.

### DIFF
--- a/monitoring/promexp/exporter.go
+++ b/monitoring/promexp/exporter.go
@@ -46,7 +46,7 @@ func NewExporter(server, namespace string, timeout time.Duration) *Exporter {
 		version: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "version"),
 			"The version of this tinode instance.",
-			[]string{"version"},
+			nil,
 			nil,
 		),
 		topicsLive: prometheus.NewDesc(


### PR DESCRIPTION
To fix "panic: inconsistent label cardinality: expected 1 label values but got 0 in []string(nil)".