### PR TITLE
touchedAt was a pointer which pointed to a shared instance of time

### DIFF
--- a/server/init_topic.go
+++ b/server/init_topic.go
@@ -221,8 +221,8 @@ func initTopicP2P(t *Topic, sreg *sessionJoin) error {
 
 		t.created = stopic.CreatedAt
 		t.updated = stopic.UpdatedAt
-		if stopic.TouchedAt != nil {
-			t.touched = *stopic.TouchedAt
+		if !stopic.TouchedAt.IsZero() {
+			t.touched = stopic.TouchedAt
 		}
 		t.lastID = stopic.SeqId
 		t.delID = stopic.DelId
@@ -584,8 +584,8 @@ func initTopicGrp(t *Topic, sreg *sessionJoin) error {
 
 	t.created = stopic.CreatedAt
 	t.updated = stopic.UpdatedAt
-	if stopic.TouchedAt != nil {
-		t.touched = *stopic.TouchedAt
+	if !stopic.TouchedAt.IsZero() {
+		t.touched = stopic.TouchedAt
 	}
 	t.lastID = stopic.SeqId
 	t.delID = stopic.DelId
@@ -618,8 +618,8 @@ func initTopicSys(t *Topic, sreg *sessionJoin) error {
 
 	t.created = stopic.CreatedAt
 	t.updated = stopic.UpdatedAt
-	if stopic.TouchedAt != nil {
-		t.touched = *stopic.TouchedAt
+	if !stopic.TouchedAt.IsZero() {
+		t.touched = stopic.TouchedAt
 	}
 	t.lastID = stopic.SeqId
 

--- a/server/store/store.go
+++ b/server/store/store.go
@@ -392,7 +392,7 @@ var Topics TopicsObjMapper
 func (TopicsObjMapper) Create(topic *types.Topic, owner types.Uid, private interface{}) error {
 
 	topic.InitTimes()
-	topic.TouchedAt = &topic.CreatedAt
+	topic.TouchedAt = topic.CreatedAt
 	topic.Owner = owner.String()
 
 	err := adp.TopicCreate(topic)
@@ -416,9 +416,9 @@ func (TopicsObjMapper) Create(topic *types.Topic, owner types.Uid, private inter
 // CreateP2P creates a P2P topic by generating two user's subsciptions to each other.
 func (TopicsObjMapper) CreateP2P(initiator, invited *types.Subscription) error {
 	initiator.InitTimes()
-	initiator.SetTouchedAt(&initiator.CreatedAt)
+	initiator.SetTouchedAt(initiator.CreatedAt)
 	invited.InitTimes()
-	invited.SetTouchedAt((&invited.CreatedAt))
+	invited.SetTouchedAt(invited.CreatedAt)
 
 	return adp.TopicCreateP2P(initiator, invited)
 }

--- a/server/store/types/types.go
+++ b/server/store/types/types.go
@@ -706,7 +706,7 @@ type Subscription struct {
 	// deserialized SeqID from user or topic
 	seqId int
 	// Deserialized TouchedAt from topic
-	touchedAt *time.Time
+	touchedAt time.Time
 	// timestamp when the user was last online
 	lastSeen time.Time
 	// user agent string of the last online access
@@ -739,18 +739,18 @@ func (s *Subscription) GetWith() string {
 }
 
 // GetTouchedAt returns touchedAt.
-func (s *Subscription) GetTouchedAt() *time.Time {
+func (s *Subscription) GetTouchedAt() time.Time {
 	return s.touchedAt
 }
 
 // SetTouchedAt sets the value of touchedAt.
-func (s *Subscription) SetTouchedAt(touchedAt *time.Time) {
-	if s.touchedAt == nil || touchedAt.After(*s.touchedAt) {
+func (s *Subscription) SetTouchedAt(touchedAt time.Time) {
+	if touchedAt.After(s.touchedAt) {
 		s.touchedAt = touchedAt
 	}
 
 	if s.touchedAt.Before(s.UpdatedAt) {
-		s.touchedAt = &s.UpdatedAt
+		s.touchedAt = s.UpdatedAt
 	}
 }
 
@@ -812,7 +812,7 @@ type Topic struct {
 	ObjHeader
 
 	// Timestamp when the last message has passed through the topic
-	TouchedAt *time.Time
+	TouchedAt time.Time
 
 	// Use bearer token or use ACL
 	UseBt bool

--- a/server/topic.go
+++ b/server/topic.go
@@ -1696,7 +1696,12 @@ func (t *Topic) replyGetSub(sess *Session, asUid types.Uid, authLevel auth.Level
 
 				if !deleted && !banned {
 					if isReader {
-						mts.TouchedAt = sub.GetTouchedAt()
+						if sub.GetTouchedAt().IsZero() {
+							mts.TouchedAt = nil
+						} else {
+							touchedAt := sub.GetTouchedAt()
+							mts.TouchedAt = &touchedAt
+						}
 						mts.SeqId = sub.GetSeqId()
 						mts.DelId = sub.DelId
 					} else {


### PR DESCRIPTION
A similar bug probably exists with `DeletedAt`.