### PR TITLE
Pass unroutable {pres} params in intra-cluster messages

### DIFF
--- a/server/cluster.go
+++ b/server/cluster.go
@@ -122,8 +122,9 @@ type ClusterReq struct {
 	Sess *ClusterSess
 	// True if the original session has disconnected
 	SessGone bool
-	// For {pres} messages, indicates whether to break reply loop.
-	PresWantReply bool
+
+	// UNroutable components of {pres} message which have to be sent intra-cluster.
+	SrvPres ClusterPresExt
 }
 
 // ClusterResp is a Master to Proxy response message.
@@ -131,6 +132,27 @@ type ClusterResp struct {
 	Msg []byte
 	// Session ID to forward message to, if any.
 	FromSID string
+}
+
+// ClusterPresExt encapsulates externally unroutable parameters of {pres} message which has to be sent intra-cluster.
+type ClusterPresExt struct {
+	// Flag to break the reply loop
+	WantReply bool
+
+	// Additional access mode filters when senting to topic's online members. Both filter conditions must be true.
+	// send only to those who have this access mode.
+	FilterIn int
+	// skip those who have this access mode.
+	FilterOut int
+
+	// When sending to 'me', skip sessions subscribed to this topic
+	SkipTopic string
+
+	// Send to sessions of a single user only
+	SingleUser string
+
+	// Exclude sessions of a single user
+	ExcludeUser string
 }
 
 // Handle outbound node communication: read messages from the channel, forward to remote nodes.
@@ -392,8 +414,13 @@ func (c *Cluster) Route(msg *ClusterReq, rejected *bool) error {
 		return nil
 	}
 	msg.SrvMsg.rcptto = msg.RcptTo
-	if msg.SrvMsg.Pres != nil && msg.PresWantReply {
-		msg.SrvMsg.Pres.wantReply = true
+	if msg.SrvMsg.Pres != nil {
+		msg.SrvMsg.Pres.wantReply = msg.SrvPres.WantReply
+		msg.SrvMsg.Pres.filterIn = msg.SrvPres.FilterIn
+		msg.SrvMsg.Pres.filterOut = msg.SrvPres.FilterOut
+		msg.SrvMsg.Pres.skipTopic = msg.SrvPres.SkipTopic
+		msg.SrvMsg.Pres.singleUser = msg.SrvPres.SingleUser
+		msg.SrvMsg.Pres.excludeUser = msg.SrvPres.ExcludeUser
 	}
 	globals.hub.route <- msg.SrvMsg
 	return nil
@@ -580,8 +607,13 @@ func (c *Cluster) routeToTopicIntraCluster(topic string, msg *ServerComMessage) 
 		Fingerprint: c.fingerprint,
 		RcptTo:      topic,
 		SrvMsg:      msg}
-	if msg.Pres != nil && msg.Pres.wantReply {
-		req.PresWantReply = true
+	if msg.Pres != nil {
+		req.SrvPres.WantReply = msg.Pres.wantReply
+		req.SrvPres.FilterIn = msg.Pres.filterIn
+		req.SrvPres.FilterOut = msg.Pres.filterOut
+		req.SrvPres.SkipTopic = msg.Pres.skipTopic
+		req.SrvPres.SingleUser = msg.Pres.singleUser
+		req.SrvPres.ExcludeUser = msg.Pres.excludeUser
 	}
 
 	return n.route(req)

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -134,7 +134,7 @@ type ClusterResp struct {
 	FromSID string
 }
 
-// ClusterPresExt encapsulates externally unroutable parameters of {pres} message which has to be sent intra-cluster.
+// ClusterPresExt encapsulates externally unroutable parameters of {pres} message which have to be sent intra-cluster.
 type ClusterPresExt struct {
 	// Flag to break the reply loop
 	WantReply bool

--- a/server/datamodel.go
+++ b/server/datamodel.go
@@ -461,7 +461,7 @@ type MsgServerPres struct {
 	// to allow different handling on the client
 	Acs *MsgAccessMode `json:"dacs,omitempty"`
 
-	// UNroutable params
+	// UNroutable params. If parameteres here change, ClusterPresExt must be updated too.
 
 	// Flag to break the reply loop
 	wantReply bool


### PR DESCRIPTION
This fixes spurious / duplicate `{pres}` notifications when running in a cluster.