### PR TITLE
Memory leak in cluster sessions, cosmetics for monitoring

### DIFF
--- a/server/cluster.go
+++ b/server/cluster.go
@@ -279,7 +279,6 @@ func (n *ClusterNode) callAsync(proc string, msg, resp interface{}, done chan *r
 
 // Proxy forwards message to master
 func (n *ClusterNode) forward(msg *ClusterReq) error {
-	// log.Printf("cluster: forwarding request to node '%s'", n.name)
 	msg.Node = globals.cluster.thisNodeName
 	var rejected bool
 	err := n.call("Cluster.Master", msg, &rejected)
@@ -291,14 +290,12 @@ func (n *ClusterNode) forward(msg *ClusterReq) error {
 
 // Master responds to proxy
 func (n *ClusterNode) respond(msg *ClusterResp) error {
-	// log.Printf("cluster: replying to node '%s'", n.name)
 	var unused bool
 	return n.call("Cluster.Proxy", msg, &unused)
 }
 
 // Routes the message within the cluster.
 func (n *ClusterNode) route(msg *ClusterReq) error {
-	// log.Printf("cluster: routing message for topic '%s' to node '%s'", msg.RcptTo, n.name)
 	var unused bool
 	return n.call("Cluster.Route", msg, &unused)
 }
@@ -329,8 +326,6 @@ type Cluster struct {
 // dispatch the message to it like it came from a normal ws/lp connection.
 // Called by a remote node.
 func (c *Cluster) Master(msg *ClusterReq, rejected *bool) error {
-	// log.Printf("cluster: Master request received from node '%s'", msg.Node)
-
 	// Find the local session associated with the given remote session.
 	sess := globals.sessionStore.Get(msg.Sess.Sid)
 
@@ -408,8 +403,6 @@ func (Cluster) Proxy(msg *ClusterResp, unused *bool) error {
 // Route endpoint receives intra-cluster messages (e.g. pres) destined for the nodes hosting topic.
 // Called by Hub.route channel consumer.
 func (c *Cluster) Route(msg *ClusterReq, rejected *bool) error {
-	// log.Printf("cluster: node '%s' received route request for topic '%s' from node '%s'", c.thisNodeName, msg.RcptTo, msg.Node)
-
 	*rejected = false
 	if msg.Signature != c.ring.Signature() {
 		log.Println("cluster Route: session signature mismatch", msg.Sess.Sid)
@@ -432,7 +425,6 @@ func (c *Cluster) Route(msg *ClusterReq, rejected *bool) error {
 
 // UserCacheUpdate endpoint receives updates to user's cached values as well as sends push notifications.
 func (c *Cluster) UserCacheUpdate(msg *UserCacheReq, rejected *bool) error {
-	// log.Printf("cluster: node '%s' received user cache update from node '%s'", c.thisNodeName, msg.Node)
 	usersRequestFromCluster(msg)
 	return nil
 }

--- a/server/cluster_leader.go
+++ b/server/cluster_leader.go
@@ -252,7 +252,7 @@ func (c *Cluster) run() {
 
 	// Count of missed pings from the leader.
 	missed := 0
-	// Don't rehash immediately on the first ping. If this node just came onlyne, leader will
+	// Don't rehash immediately on the first ping. If this node just came online, leader will
 	// account it on the next ping. Otherwise it will be rehashing twice.
 	rehashSkipped := false
 

--- a/server/cluster_leader.go
+++ b/server/cluster_leader.go
@@ -238,7 +238,7 @@ func (c *Cluster) electLeader() {
 	}
 
 	if voteCount >= expectVotes {
-		// Current node elected as the leader
+		// Current node elected as the leader.
 		c.fo.leader = c.thisNodeName
 		statsSet("ClusterLeader", 1)
 		log.Printf("'%s' elected self as a new leader", c.thisNodeName)
@@ -267,7 +267,7 @@ func (c *Cluster) run() {
 				// The counter will be reset to zero when the ping is received.
 				missed++
 				if missed >= c.fo.voteTimeout {
-					// Elect the leader
+					// Leader is gone, initiate election of a new leader.
 					missed = 0
 					c.electLeader()
 				}
@@ -296,6 +296,9 @@ func (c *Cluster) run() {
 				c.fo.leader = ping.Leader
 			}
 
+			// This ping is from a leader, consequently this node is not the leader.
+			statsSet("ClusterLeader", 0)
+
 			missed = 0
 			if ping.Signature != c.ring.Signature() {
 				if rehashSkipped {
@@ -318,6 +321,8 @@ func (c *Cluster) run() {
 				log.Printf("Voting YES for %s, my term %d, vote term %d", vreq.req.Node, c.fo.term, vreq.req.Term)
 				c.fo.term = vreq.req.Term
 				c.fo.leader = ""
+				// Election means these is no leader yet.
+				statsSet("ClusterLeader", 0)
 				vreq.resp <- ClusterVoteResponse{Result: true, Term: c.fo.term}
 			} else {
 				// This node has voted already or stale election, reject.

--- a/server/session.go
+++ b/server/session.go
@@ -58,25 +58,25 @@ type Session struct {
 	// protocol - NONE (unset), WEBSOCK, LPOLL, CLUSTER, GRPC
 	proto int
 
-	// Websocket. Set only for websocket sessions
+	// Websocket. Set only for websocket sessions.
 	ws *websocket.Conn
 
-	// Pointer to session's record in sessionStore. Set only for Long Poll sessions
+	// Pointer to session's record in sessionStore. Set only for Long Poll sessions.
 	lpTracker *list.Element
 
-	// gRPC handle. Set only for gRPC clients
+	// gRPC handle. Set only for gRPC clients.
 	grpcnode pbx.Node_MessageLoopServer
 
-	// Reference to the cluster node where the session has originated. Set only for cluster RPC sessions
+	// Reference to the cluster node where the session has originated. Set only for cluster RPC (proxied) sessions.
 	clnode *ClusterNode
 
-	// IP address of the client. For long polling this is the IP of the last poll
+	// IP address of the client. For long polling this is the IP of the last poll.
 	remoteAddr string
 
-	// User agent, a string provived by an authenticated client in {login} packet
+	// User agent, a string provived by an authenticated client in {login} packet.
 	userAgent string
 
-	// Protocol version of the client: ((major & 0xff) << 8) | (minor & 0xff)
+	// Protocol version of the client: ((major & 0xff) << 8) | (minor & 0xff).
 	ver int
 
 	// Device ID of the client
@@ -163,6 +163,10 @@ func (s *Session) delSub(topic string) {
 	defer s.subsLock.Unlock()
 
 	delete(s.subs, topic)
+}
+
+func (s *Session) countSub() int {
+	return len(s.subs)
 }
 
 // Inform topics that the session is being terminated.

--- a/server/sessionstore.go
+++ b/server/sessionstore.go
@@ -39,7 +39,16 @@ type SessionStore struct {
 func (ss *SessionStore) NewSession(conn interface{}, sid string) (*Session, int) {
 	var s Session
 
-	s.sid = sid
+	if sid == "" {
+		s.sid = store.GetUidString()
+	} else {
+		s.sid = sid
+	}
+
+	if _, found := ss.sessCache[s.sid]; found {
+		// TODO: change to panic or log.Fatal
+		log.Println("ERROR! duplicate session ID", s.sid)
+	}
 
 	switch c := conn.(type) {
 	case *websocket.Conn:
@@ -63,41 +72,41 @@ func (ss *SessionStore) NewSession(conn interface{}, sid string) (*Session, int)
 		s.send = make(chan interface{}, sendQueueLimit+32) // buffered
 		s.stop = make(chan interface{}, 1)                 // Buffered by 1 just to make it non-blocking
 		s.detach = make(chan string, 64)                   // buffered
-		if globals.cluster != nil {
+
+		if globals.cluster != nil && s.proto != CLUSTER {
+			// This is only useful when running as a cluster and only for non-proxied sessions.
 			s.remoteSubs = make(map[string]*RemoteSubscription)
 		}
 	}
 
 	s.lastTouched = time.Now()
-	if s.sid == "" {
-		s.sid = store.GetUidString()
-	}
 
 	ss.lock.Lock()
 
-	ss.sessCache[s.sid] = &s
-	count := len(ss.sessCache)
-	var expired []*Session
 	if s.proto == LPOLL {
 		// Only LP sessions need to be sorted by last active
 		s.lpTracker = ss.lru.PushFront(&s)
-
-		// Remove expired sessions
-		expire := s.lastTouched.Add(-ss.lifeTime)
-		for elem := ss.lru.Back(); elem != nil; elem = ss.lru.Back() {
-			sess := elem.Value.(*Session)
-			if sess.lastTouched.Before(expire) {
-				ss.lru.Remove(elem)
-				delete(ss.sessCache, sess.sid)
-				expired = append(expired, sess)
-			} else {
-				break // don't need to traverse further
-			}
-		}
-		count -= len(expired)
 	}
+
+	ss.sessCache[s.sid] = &s
+
+	// Expire stale long polling sessions.
+	var expired []*Session
+	expire := s.lastTouched.Add(-ss.lifeTime)
+	for elem := ss.lru.Back(); elem != nil; elem = ss.lru.Back() {
+		sess := elem.Value.(*Session)
+		if sess.lastTouched.Before(expire) {
+			ss.lru.Remove(elem)
+			delete(ss.sessCache, sess.sid)
+			expired = append(expired, sess)
+		} else {
+			break // don't need to traverse further
+		}
+	}
+
 	ss.lock.Unlock()
 
+	// Deleting long polling sessions.
 	for _, sess := range expired {
 		// This locks the session. Thus cleaning up outside of the
 		// sessionStore lock. Otherwise deadlock.
@@ -107,7 +116,7 @@ func (ss *SessionStore) NewSession(conn interface{}, sid string) (*Session, int)
 	statsSet("LiveSessions", int64(len(ss.sessCache)))
 	statsInc("TotalSessions", 1)
 
-	return &s, count
+	return &s, len(ss.sessCache)
 }
 
 // Get fetches a session from store by session ID.

--- a/server/sessionstore.go
+++ b/server/sessionstore.go
@@ -90,7 +90,8 @@ func (ss *SessionStore) NewSession(conn interface{}, sid string) (*Session, int)
 
 	ss.sessCache[s.sid] = &s
 
-	// Expire stale long polling sessions.
+	// Expire stale long polling sessions: ss.lru contains only long polling sessions.
+	// If ss.lru is empty this is a noop.
 	var expired []*Session
 	expire := s.lastTouched.Add(-ss.lifeTime)
 	for elem := ss.lru.Back(); elem != nil; elem = ss.lru.Back() {

--- a/server/stats.go
+++ b/server/stats.go
@@ -9,6 +9,7 @@ import (
 	"expvar"
 	"log"
 	"net/http"
+	"time"
 )
 
 type varUpdate struct {
@@ -28,6 +29,11 @@ func statsInit(mux *http.ServeMux, path string) {
 
 	mux.Handle(path, expvar.Handler())
 	globals.statsUpdate = make(chan *varUpdate, 1024)
+
+	start := time.Now()
+	expvar.Publish("Uptime", expvar.Func(func() interface{} {
+		return time.Since(start).Seconds()
+	}))
 
 	go statsUpdater()
 


### PR DESCRIPTION
Changes:
1. Memory leak, line 765 in `server/cluster.go`
https://github.com/tinode/chat/compare/devel...cluster2?expand=1#diff-d412b9240514b30a308e4b4c8208ae72R765
2. Removed initialization of `Session.remoteSubs` from proxied cluster sessions because it's not used.
3. Added check for duplicate session IDs.
4. Some cosmetic changes for monitoring: version number as decimal as opposite to hex, uptime.
5. Some debug logging removed, some `Printf`s replaced with `Println`s as the latter is better performing. 
6. fixed a small memory waste in long polling. It's minor and unrelated to that massive leak.