### PR TITLE
fix for double routing of {sub topic=new} in cluster

### DIFF
--- a/server/datamodel.go
+++ b/server/datamodel.go
@@ -307,7 +307,7 @@ type ClientComMessage struct {
 
 	// Message ID denormalized
 	id string
-	// Topic denormalized
+	// Un-routable (original) topic name denormalized from XXX.Topic.
 	topic string
 	// Sender's UserId as string
 	from string

--- a/server/push/fcm/payload.go
+++ b/server/push/fcm/payload.go
@@ -1,5 +1,3 @@
-// Package fcm is push notification plugin using Google FCM.
-// https://firebase.google.com/docs/cloud-messaging
 package fcm
 
 import (

--- a/server/session.go
+++ b/server/session.go
@@ -403,10 +403,10 @@ func (s *Session) subscribe(msg *ClientComMessage) {
 	var expanded string
 	isNewTopic := false
 	if strings.HasPrefix(msg.topic, "new") {
-		// Request to create a new named topic
-		expanded = genTopicName()
+		// Request to create a new named topic.
+		// If we are in a cluster, make sure the new topic belongs to the current node.
+		expanded = globals.cluster.genLocalTopicName()
 		isNewTopic = true
-		// msg.topic = expanded
 	} else {
 		var resp *ServerComMessage
 		expanded, resp = s.expandTopicName(msg)


### PR DESCRIPTION
The other option was to generate topic name on the session origin node then send it to the master node which is a bit more complex. I think this approach is ok while the number of nodes is not too large (~20 nodes should be fine).