### PR TITLE
Topic Proxy: leave request handling

### DIFF
--- a/server/cluster.go
+++ b/server/cluster.go
@@ -526,7 +526,6 @@ func (c *Cluster) TopicMaster(msg *ClusterReq, rejected *bool) error {
 		// If the session is not found, create it.
 		var count int
 		sess, count = globals.sessionStore.NewSession(node, sid)
-    sess.isProxy = true
 
 		log.Println("cluster: topic proxy channel started", sid, count)
 		go sess.topicProxyWriteLoop(msg.RcptTo)
@@ -1216,7 +1215,7 @@ func (sess *Session) topicProxyWriteLoop(forTopic string) {
 			if srvMsg.sessOverrides != nil {
 				switch req := srvMsg.sessOverrides.origReq.(type) {
 				case nil:
-					log.Println("origReq is nil")
+					panic("cluster: origReq is nil in session overrides")
 				case *ProxyJoin:
 					response.ProxyResp.OrigRequestType = ProxyRequestJoin
 				case *ProxyLeave:

--- a/server/hub.go
+++ b/server/hub.go
@@ -50,12 +50,15 @@ type sessionLeave struct {
 	topic string
 	// Session which initiated the request
 	sess *Session
-	// The session is a special session for a remote proxy topic.
-	terminateRemoteSession bool
+	// Should the proxy-master topic connection be terminated
+	terminateProxyConnection bool
 	// Leave and unsubscribe
 	unsub bool
 	// ID of originating request, if any
 	id string
+
+	// Session param overrides. Used for handling remote (proxy-master) topic requests.
+	sessOverrides *sessionOverrides
 }
 
 // Request to hub to remove the topic

--- a/server/hub.go
+++ b/server/hub.go
@@ -50,6 +50,8 @@ type sessionLeave struct {
 	topic string
 	// Session which initiated the request
 	sess *Session
+	// The session is a special session for a remote proxy topic.
+	terminateRemoteSession bool
 	// Leave and unsubscribe
 	unsub bool
 	// ID of originating request, if any

--- a/server/session.go
+++ b/server/session.go
@@ -125,6 +125,9 @@ type Session struct {
 	// Session ID
 	sid string
 
+	// Indicates whether this session is used as a local interface for a remote proxy topic.
+	isProxy bool
+
 	// Needed for long polling and grpc.
 	lock sync.Mutex
 }

--- a/server/session.go
+++ b/server/session.go
@@ -125,9 +125,6 @@ type Session struct {
 	// Session ID
 	sid string
 
-	// Indicates whether this session is used as a local interface for a remote proxy topic.
-	isProxy bool
-
 	// Needed for long polling and grpc.
 	lock sync.Mutex
 }
@@ -204,6 +201,11 @@ func (s *Session) delRemoteSub(topic string) {
 	defer s.remoteSubsLock.Unlock()
 
 	delete(s.remoteSubs, topic)
+}
+
+// Indicates whether this session is used as a local interface for a remote proxy topic.
+func (s *Session) isProxy() bool {
+  return s.proto == CLUSTER
 }
 
 // queueOut attempts to send a ServerComMessage to a session; if the send buffer is full,


### PR DESCRIPTION
Pass over session leave requests to the topic master and
clean up master & proxy topics (and their helper sessions) when there are no more attached sessions to them.

Note that this PR is an intermediate version. There's more work to be done to property handle subscribe/unsubscribe.