### PR TITLE
Topic proxy: more bug fixes

### DIFF
--- a/server/cluster.go
+++ b/server/cluster.go
@@ -1251,9 +1251,7 @@ func (sess *Session) topicProxyWriteLoop(forTopic string) {
 					// Only presence notifications may come not as a response to a client request.
 					log.Panic("cluster: message must be accompanied by the originating session information: ", srvMsg)
 				}
-				if srvMsg.skipSid != "" {
-					response.ProxyResp.SkipSid = srvMsg.skipSid
-				}
+				response.ProxyResp.SkipSid = srvMsg.skipSid
 			}
 			if copyParamsFromSession {
 				// Reply to a specific session.

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -584,7 +584,7 @@ func (c *Cluster) TopicMaster(msg *ClusterReq, rejected *bool) error {
 
 	case msg.TopicMsg.MetaReq != nil:
 		if !uid.IsZero() {
-			log.Println("join setting uid = ", uid)
+			log.Println("meta setting uid = ", uid)
 			msg.CliMsg.from = uid.UserId()
 		}
 		msg.CliMsg.authLvl = int(authLvl)
@@ -1245,6 +1245,15 @@ func (sess *Session) topicProxyWriteLoop(forTopic string) {
 					response.ProxyResp.OrigRequestType = ProxyRequestMeta
 				}
 				copyParamsFromSession = srvMsg.sessOverrides.sid != ""
+			} else {
+				// Copy skipSid.
+				if srvMsg.Pres == nil {
+					// Only presence notifications may come not as a response to a client request.
+					log.Panic("cluster: message must be accompanied by the originating session information: ", srvMsg)
+				}
+				if srvMsg.skipSid != "" {
+					response.ProxyResp.SkipSid = srvMsg.skipSid
+				}
 			}
 			if copyParamsFromSession {
 				// Reply to a specific session.

--- a/server/topic.go
+++ b/server/topic.go
@@ -221,7 +221,7 @@ func (t *Topic) runProxy(hub *Hub) {
 			log.Printf("t[%s] leave %+v", t.name, leave)
 			asUid := leave.userId
 			// Explicitly specify user id because the proxy session hosts multiple client sessions.
-			if leave.userId.IsZero() {
+			if asUid.IsZero() {
 				if pssd, ok := t.sessions[leave.sess]; ok {
 					asUid = pssd.uid
 				} else {
@@ -530,7 +530,7 @@ func (t *Topic) runLocal(hub *Hub) {
 					}
 					// Update user's last online timestamp & user agent
 					if !proxyTerminating {
-						if err := store.Users.UpdateLastSeen(asUid, mrs.userAgent, now); err != nil {
+						if err := store.Users.UpdateLastSeen(uid, mrs.userAgent, now); err != nil {
 							log.Println(err)
 						}
 					}


### PR DESCRIPTION
Fixes for the following:
* skipSid not set on {pres} messages initiated by the master topics as a response to client requests (e.g. user A changes permissions for user B on a topic but receives pres notifications addressed to B)
* uid may be zero when processing proxy session leave requests. This updates the `Topic.perUser` map incorrectly.