### PR TITLE
Rename {ClientComMessage,ServerComMessage}.from -> asUser.

### DIFF
--- a/server/cluster.go
+++ b/server/cluster.go
@@ -374,7 +374,7 @@ func (c *Cluster) Master(msg *ClusterReq, rejected *bool) error {
 		sess.platf = msg.Sess.Platform
 
 		// Dispatch remote message to a local session.
-		msg.CliMsg.from = msg.OnBehalfOf
+		msg.CliMsg.asUser = msg.OnBehalfOf
 		msg.CliMsg.authLvl = msg.AuthLvl
 		sess.dispatch(msg.CliMsg)
 	} else {
@@ -605,7 +605,7 @@ func (c *Cluster) routeToTopic(msg *ClientComMessage, topic string, sess *Sessio
 
 	if sess.authLvl == auth.LevelRoot {
 		// Assign these values only when the sender is root
-		req.OnBehalfOf = msg.from
+		req.OnBehalfOf = msg.asUser
 		req.AuthLvl = msg.authLvl
 	}
 

--- a/server/datamodel.go
+++ b/server/datamodel.go
@@ -310,7 +310,7 @@ type ClientComMessage struct {
 	// Un-routable (original) topic name denormalized from XXX.Topic.
 	topic string
 	// Sender's UserId as string
-	from string
+	asUser string
 	// Sender's authentication level
 	authLvl int
 	// Timestamp when this message was received by the server
@@ -578,7 +578,7 @@ type ServerComMessage struct {
 	// timestamp for consistency of timestamps in {ctrl} messages
 	timestamp time.Time
 	// User ID of the sender of the original message.
-	from string
+	asUser string
 	// Originating session to send an aknowledgement to. Could be nil.
 	sess *Session
 	// Should the packet be sent to the original session? SessionID to skip.
@@ -595,7 +595,7 @@ func (src *ServerComMessage) copy() *ServerComMessage {
 		id:        src.id,
 		rcptto:    src.rcptto,
 		timestamp: src.timestamp,
-		from:      src.from,
+		asUser:    src.asUser,
 		sess:      src.sess,
 		skipSid:   src.skipSid,
 	}

--- a/server/hub.go
+++ b/server/hub.go
@@ -357,7 +357,7 @@ func (h *Hub) topicUnreg(sess *Session, topic string, msg *ClientComMessage, rea
 	now := time.Now().UTC().Round(time.Millisecond)
 
 	if reason == StopDeleted {
-		asUid := types.ParseUserId(msg.from)
+		asUid := types.ParseUserId(msg.asUser)
 		// Case 1 (unregister and delete)
 		if t := h.topicGet(topic); t != nil {
 			// Case 1.1: topic is online
@@ -389,7 +389,7 @@ func (h *Hub) topicUnreg(sess *Session, topic string, msg *ClientComMessage, rea
 		} else {
 			// Case 1.2: topic is offline.
 
-			asUid := types.ParseUserId(msg.from)
+			asUid := types.ParseUserId(msg.asUser)
 			// Get all subscribers: we need to know how many are left and notify them.
 			subs, err := store.Topics.GetSubs(topic, nil)
 			if err != nil {
@@ -535,7 +535,7 @@ func (h *Hub) stopTopicsForUser(uid types.Uid, reason int, alldone chan<- bool) 
 func replyOfflineTopicGetDesc(sess *Session, topic string, msg *ClientComMessage) {
 	now := types.TimeNow()
 	desc := &MsgTopicDesc{}
-	asUid := types.ParseUserId(msg.from)
+	asUid := types.ParseUserId(msg.asUser)
 
 	if strings.HasPrefix(topic, "grp") {
 		stopic, err := store.Topics.Get(topic)
@@ -552,7 +552,7 @@ func replyOfflineTopicGetDesc(sess *Session, topic string, msg *ClientComMessage
 		desc.CreatedAt = &stopic.CreatedAt
 		desc.UpdatedAt = &stopic.UpdatedAt
 		desc.Public = stopic.Public
-		if stopic.Owner == msg.from {
+		if stopic.Owner == msg.asUser {
 			desc.DefaultAcs = &MsgDefaultAcsMode{
 				Auth: stopic.Access.Auth.String(),
 				Anon: stopic.Access.Anon.String()}
@@ -624,12 +624,12 @@ func replyOfflineTopicGetDesc(sess *Session, topic string, msg *ClientComMessage
 func replyOfflineTopicGetSub(sess *Session, topic string, msg *ClientComMessage) {
 	now := types.TimeNow()
 
-	if msg.Get.Sub != nil && msg.Get.Sub.User != "" && msg.Get.Sub.User != msg.from {
+	if msg.Get.Sub != nil && msg.Get.Sub.User != "" && msg.Get.Sub.User != msg.asUser {
 		sess.queueOut(ErrPermissionDenied(msg.id, msg.topic, now))
 		return
 	}
 
-	ssub, err := store.Subs.Get(topic, types.ParseUserId(msg.from))
+	ssub, err := store.Subs.Get(topic, types.ParseUserId(msg.asUser))
 	if err != nil {
 		log.Println("replyOfflineTopicGetSub:", err)
 		sess.queueOut(decodeStoreError(err, msg.id, msg.topic, now, nil))
@@ -673,12 +673,12 @@ func replyOfflineTopicSetSub(sess *Session, topic string, msg *ClientComMessage)
 		return
 	}
 
-	if msg.Set.Sub != nil && msg.Set.Sub.User != "" && msg.Set.Sub.User != msg.from {
+	if msg.Set.Sub != nil && msg.Set.Sub.User != "" && msg.Set.Sub.User != msg.asUser {
 		sess.queueOut(ErrPermissionDenied(msg.id, msg.topic, now))
 		return
 	}
 
-	asUid := types.ParseUserId(msg.from)
+	asUid := types.ParseUserId(msg.asUser)
 
 	sub, err := store.Subs.Get(topic, asUid)
 	if err != nil {

--- a/server/init_topic.go
+++ b/server/init_topic.go
@@ -266,7 +266,7 @@ func initTopicP2P(t *Topic, sreg *sessionJoin) error {
 
 		// Fetching records for both users.
 		// Requester.
-		userID1 := types.ParseUserId(sreg.pkt.from)
+		userID1 := types.ParseUserId(sreg.pkt.asUser)
 		// The other user.
 		userID2 := types.ParseUserId(t.xoriginal)
 		// User index: u1 - requester, u2 - responder, the other user
@@ -463,7 +463,7 @@ func initTopicNewGrp(t *Topic, sreg *sessionJoin) error {
 	t.cat = types.TopicCatGrp
 
 	// Generic topics have parameters stored in the topic object
-	t.owner = types.ParseUserId(sreg.pkt.from)
+	t.owner = types.ParseUserId(sreg.pkt.asUser)
 
 	t.accessAuth = getDefaultAccess(t.cat, true)
 	t.accessAnon = getDefaultAccess(t.cat, false)

--- a/server/pbconverter.go
+++ b/server/pbconverter.go
@@ -302,7 +302,7 @@ func pbCliSerialize(msg *ClientComMessage) *pbx.ClientMsg {
 		return nil
 	}
 
-	pkt.OnBehalfOf = msg.from
+	pkt.OnBehalfOf = msg.asUser
 	pkt.AuthLevel = pbx.AuthLevel(msg.authLvl)
 
 	return &pkt
@@ -409,7 +409,7 @@ func pbCliDeserialize(pkt *pbx.ClientMsg) *ClientComMessage {
 		}
 	}
 
-	msg.from = pkt.GetOnBehalfOf()
+	msg.asUser = pkt.GetOnBehalfOf()
 	msg.authLvl = int(pkt.GetAuthLevel())
 
 	return &msg

--- a/server/user.go
+++ b/server/user.go
@@ -195,14 +195,14 @@ func replyUpdateUser(s *Session, msg *ClientComMessage, rec *auth.Rec) {
 		log.Println("replyUpdateUser: not a new account and not authenticated", s.sid)
 		s.queueOut(ErrPermissionDenied(msg.id, "", msg.timestamp))
 		return
-	} else if msg.from != "" && rec != nil {
+	} else if msg.asUser != "" && rec != nil {
 		// Two UIDs: one from msg.from, one from token. Ambigous, reject.
 		log.Println("replyUpdateUser: got both authenticated session and token", s.sid)
 		s.queueOut(ErrMalformed(msg.id, "", msg.timestamp))
 		return
 	}
 
-	userId := msg.from
+	userId := msg.asUser
 	authLvl := auth.Level(msg.authLvl)
 	if rec != nil {
 		userId = rec.Uid.UserId()


### PR DESCRIPTION
As discussed in https://github.com/tinode/chat/pull/434