### PR TITLE
Topic Proxy: deferred notifications (part 2).

### DIFF
--- a/server/cluster.go
+++ b/server/cluster.go
@@ -178,6 +178,8 @@ type ProxyTopicData struct {
 	LeaveReq *ProxyLeave
 	// User agent change request.
 	UAChangeReq *ProxyUAChange
+	// Send deferred notifications request.
+	DefrNotifReq *ProxyDeferredNotifications
 }
 
 // ProxyJoin contains topic join request parameters.
@@ -190,8 +192,6 @@ type ProxyJoin struct {
 	Newsub bool
 	// True if this topic is created internally.
 	Internal bool
-	// True if it's a background join request.
-	Background bool
 }
 
 // ProxyBroadcast contains topic broadcast request parameters.
@@ -228,6 +228,19 @@ type ProxyLeave struct {
 type ProxyUAChange struct {
 	// User agent string.
 	UserAgent string
+}
+
+// ProxyDeferredSession represents a background session
+// for which we want to send deferred notifications.
+type ProxyDeferredSession struct {
+	// User this session represents.
+	AsUser    string
+}
+
+// ProxyDeferredNotifications contains a list of sessions
+// for which deferred notifications will be sent.
+type ProxyDeferredNotifications struct {
+	SendNotificationRequests []*ProxyDeferredSession
 }
 
 // Proxy request types.
@@ -530,7 +543,11 @@ func (c *Cluster) TopicMaster(msg *ClusterReq, rejected *bool) error {
 		origSid = ""
 		authLvl = auth.LevelNone
 	} else {
-		uid = msg.Sess.Uid
+		if msg.OnBehalfOf != "" {
+			uid = types.ParseUserId(msg.OnBehalfOf)
+		} else {
+			uid = msg.Sess.Uid
+		}
 		origSid = msg.Sess.Sid
 		authLvl = msg.Sess.AuthLvl
 	}
@@ -565,6 +582,7 @@ func (c *Cluster) TopicMaster(msg *ClusterReq, rejected *bool) error {
 				sid:     origSid,
 				rcptTo:  msg.RcptTo,
 				origReq: msg.TopicMsg.JoinReq,
+				cliMsg:  msg.CliMsg,
 			},
 		}
 		globals.hub.join <- sessionJoin
@@ -644,6 +662,14 @@ func (c *Cluster) TopicMaster(msg *ClusterReq, rejected *bool) error {
 			t.uaChange <- msg.TopicMsg.UAChangeReq.UserAgent
 		} else {
 			log.Printf("cluster: UA change request for unknown topic %s", msg.RcptTo)
+		}
+
+	case msg.TopicMsg.DefrNotifReq != nil:
+		if t := globals.hub.topicGet(msg.RcptTo); t != nil {
+			// TODO: process request.
+			log.Printf("cluster: handling deferred notif req = %+v", msg.TopicMsg.DefrNotifReq.SendNotificationRequests)
+		} else {
+			log.Printf("cluster: deferred notifications request for unknown topic %s", msg.RcptTo)
 		}
 
 	default:
@@ -1276,9 +1302,10 @@ func (sess *Session) topicProxyWriteLoop(forTopic string) {
 					panic("cluster: origReq is nil in session overrides")
 				case *ProxyJoin:
 					response.ProxyResp.OrigRequestType = ProxyRequestJoin
-					if req.Background {
+					if srvMsg.sessOverrides.cliMsg.Sub.Background {
 						response.ProxyResp.IsBackground = true
 					}
+					response.ProxyResp.Uid = types.ParseUserId(srvMsg.sessOverrides.cliMsg.asUser)
 				case *ProxyLeave:
 					response.ProxyResp.OrigRequestType = ProxyRequestLeave
 					if req.TerminateProxyConnection {

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -234,7 +234,7 @@ type ProxyUAChange struct {
 // for which we want to send deferred notifications.
 type ProxyDeferredSession struct {
 	// User this session represents.
-	AsUser    string
+	AsUser string
 }
 
 // ProxyDeferredNotifications contains a list of sessions
@@ -589,11 +589,11 @@ func (c *Cluster) TopicMaster(msg *ClusterReq, rejected *bool) error {
 	case msg.TopicMsg.LeaveReq != nil:
 		if t := globals.hub.topicGet(msg.RcptTo); t != nil {
 			leave := &sessionLeave{
-				id:                       msg.TopicMsg.LeaveReq.Id,
-				userId:                   msg.TopicMsg.LeaveReq.UserId,
-				unsub:                    msg.TopicMsg.LeaveReq.Unsub,
+				id:     msg.TopicMsg.LeaveReq.Id,
+				userId: msg.TopicMsg.LeaveReq.UserId,
+				unsub:  msg.TopicMsg.LeaveReq.Unsub,
 				terminateProxyConnection: msg.TopicMsg.LeaveReq.TerminateProxyConnection,
-				sess:                     sess,
+				sess: sess,
 				sessOverrides: &sessionOverrides{
 					sid:     origSid,
 					rcptTo:  msg.RcptTo,
@@ -1269,7 +1269,7 @@ func (c *Cluster) garbageCollectProxySessions(activeNodes []string) {
 	for s, t := range sessions {
 		t.unreg <- &sessionLeave{
 			terminateProxyConnection: true,
-			sess:                     s,
+			sess: s,
 		}
 		s.stop <- nil
 	}

--- a/server/datamodel.go
+++ b/server/datamodel.go
@@ -567,7 +567,7 @@ type sessionOverrides struct {
 	userAgent string
 	// Incoming proxy topic request pointer. Set for topic proxy requests.
 	origReq interface{}
-  // Original client request.
+	// Original client request.
 	cliMsg *ClientComMessage
 }
 

--- a/server/datamodel.go
+++ b/server/datamodel.go
@@ -563,8 +563,12 @@ type sessionOverrides struct {
 	sid string
 	// Topic id the session represents.
 	rcptTo string
-	// Incoming request pointer. Set for topic proxy requests.
+	// User agent of the original session.
+	userAgent string
+	// Incoming proxy topic request pointer. Set for topic proxy requests.
 	origReq interface{}
+  // Original client request.
+	cliMsg *ClientComMessage
 }
 
 // Deep copy

--- a/server/topic.go
+++ b/server/topic.go
@@ -210,9 +210,9 @@ func (t *Topic) runProxy(hub *Hub) {
 				log.Printf("topic[%s] reg %+v", t.name, sreg)
 				msg := &ProxyTopicData{
 					JoinReq: &ProxyJoin{
-						Created:    sreg.created,
-						Newsub:     sreg.newsub,
-						Internal:   sreg.internal,
+						Created:  sreg.created,
+						Newsub:   sreg.newsub,
+						Internal: sreg.internal,
 					},
 				}
 				log.Println("sessionJoin pkt = ", sreg.pkt, sreg.topic)
@@ -3027,7 +3027,7 @@ func (t *Topic) pushForData(fromUid types.Uid, data *MsgServerData) *push.Receip
 				// Number of sessions this data message will be delivered to.
 				// Push notifications sent to users with non-zero online sessions will be marked silent.
 				Delivered: pud.online,
-      }
+			}
 		}
 	}
 	if len(receipt.To) > 0 {

--- a/server/topic.go
+++ b/server/topic.go
@@ -213,7 +213,6 @@ func (t *Topic) runProxy(hub *Hub) {
 						Created:    sreg.created,
 						Newsub:     sreg.newsub,
 						Internal:   sreg.internal,
-						Background: sreg.pkt.Sub.Background,
 					},
 				}
 				log.Println("sessionJoin pkt = ", sreg.pkt, sreg.topic)
@@ -319,7 +318,7 @@ func (t *Topic) runProxy(hub *Hub) {
 				case ProxyRequestJoin:
 					if sess != nil && msg.SrvMsg != nil && msg.SrvMsg.Ctrl != nil {
 						if msg.SrvMsg.Ctrl.Code < 300 {
-							if t.addSession(sess, sess.uid) {
+							if t.addSession(sess, msg.ProxyResp.Uid) {
 								sess.addSub(t.name, &Subscription{
 									broadcast: t.broadcast,
 									done:      t.unreg,
@@ -333,6 +332,7 @@ func (t *Topic) runProxy(hub *Hub) {
 									sreg := &sessionJoin{
 										sess: sess,
 										pkt: &ClientComMessage{
+											asUser:    msg.ProxyResp.Uid.UserId(),
 											timestamp: types.TimeNow(),
 										},
 									}
@@ -416,9 +416,7 @@ func (t *Topic) proxyFanoutBroadcast(msg *ServerComMessage) {
 		}
 		t.maybeFixTopicName(msg, pssd.uid)
 		log.Printf("broadcast fanout [%s] to %s", t.name, sess.sid)
-		if sess.queueOut(msg) {
-			// TODO: push notifications.
-		} else {
+		if !sess.queueOut(msg) {
 			log.Printf("topic[%s]: connection stuck, detaching", t.name)
 			t.unreg <- &sessionLeave{sess: sess}
 		}
@@ -1025,6 +1023,25 @@ func (t *Topic) sendDeferredNotifications(joinReqs []*sessionJoin) {
 	}
 }
 
+// routeDeferredNotificationsToMaster forwards deferred notification requests to the master topic.
+func (t *Topic) routeDeferredNotificationsToMaster(joinReqs []*sessionJoin) {
+	var sendReqs []*ProxyDeferredSession
+	for _, sreg := range joinReqs {
+		s := &ProxyDeferredSession{
+			AsUser: sreg.pkt.asUser,
+		}
+		sendReqs = append(sendReqs, s)
+	}
+	msg := &ProxyTopicData{
+		DefrNotifReq: &ProxyDeferredNotifications{
+			SendNotificationRequests: sendReqs,
+		},
+	}
+	if err := globals.cluster.routeToTopicMaster(nil, nil, msg, t.name, nil); err != nil {
+		log.Println("proxy topic: deferred notifications request from proxy to master failed:", err)
+	}
+}
+
 // onDeferredNotificationTimer removes all due deferred notifications sessions
 // from the notifications queue and for each of these sessions:
 // * For regular topics, sends all due notifications.
@@ -1055,6 +1072,7 @@ func (t *Topic) onDeferredNotificationTimer() {
 	if t.isProxy {
 		// TODO: route expired background sessions to the master topic.
 		// t.routeToMasterTopic(joinReqs)
+		t.routeDeferredNotificationsToMaster(joinReqs)
 	} else {
 		t.sendDeferredNotifications(joinReqs)
 	}
@@ -1224,7 +1242,8 @@ func (t *Topic) sendSubNotifications(asUid types.Uid, sreg *sessionJoin) {
 			// If this is the first session of the user in the topic.
 			// Notify other online group members that the user is online now.
 			t.presSubsOnline("on", asUid.UserId(), nilPresParams,
-				&presFilters{filterIn: types.ModeRead}, sreg.sess.sid)
+				&presFilters{filterIn: types.ModeRead},
+				sidFromSessionOrOverrides(sreg.sess, sreg.sessOverrides))
 		}
 	}
 }


### PR DESCRIPTION
Add some plumbing to make sure we use the proper user id
on the when subscribing origin sessions to proxy topics (after hearing
a word about a successful subscription from the master topic).
Also, add some data structures necessary for routing deferred notifications
requests to the master.