### PR TITLE
Use separate source and target topic filters in presSubsOffline.

### DIFF
--- a/server/pres.go
+++ b/server/pres.go
@@ -345,7 +345,8 @@ func (s *Session) presTermDirect(subs []string) {
 // Case L.4: Admin altered GIVEN, "acs" to admins
 // Case T: message sent, "msg" to all with 'R'
 // Case W.1: messages hard-deleted, "del" to all with 'R'
-func (t *Topic) presSubsOffline(what string, params *presParams, filter *presFilters,
+func (t *Topic) presSubsOffline(what string, params *presParams,
+	filterSource *presFilters, filterTarget *presFilters,
 	skipSid string, offlineOnly bool) {
 
 	var skipTopic string
@@ -353,9 +354,9 @@ func (t *Topic) presSubsOffline(what string, params *presParams, filter *presFil
 		skipTopic = t.name
 	}
 
-	for uid := range t.perUser {
-		if t.perUser[uid].deleted || (what != "acs" && what != "gone" &&
-			!presOfflineFilter(t.perUser[uid].modeGiven&t.perUser[uid].modeWant, filter)) {
+	for uid, pud := range t.perUser {
+		if pud.deleted || (what != "acs" && what != "gone" &&
+			!presOfflineFilter(pud.modeGiven&pud.modeWant, filterSource)) {
 			continue
 		}
 
@@ -374,8 +375,8 @@ func (t *Topic) presSubsOffline(what string, params *presParams, filter *presFil
 			Pres: &MsgServerPres{Topic: "me", What: what, Src: t.original(uid),
 				Acs: params.packAcs(), AcsActor: actor, AcsTarget: target,
 				SeqId: params.seqID, DelId: params.delID,
-				FilterIn: int(filter.filterIn), FilterOut: int(filter.filterOut),
-				SingleUser: filter.singleUser, ExcludeUser: filter.excludeUser,
+				FilterIn: int(filterTarget.filterIn), FilterOut: int(filterTarget.filterOut),
+				SingleUser: filterTarget.singleUser, ExcludeUser: filterTarget.excludeUser,
 				SkipTopic: skipTopic},
 			rcptto: user, skipSid: skipSid}
 	}

--- a/server/topic.go
+++ b/server/topic.go
@@ -1615,9 +1615,8 @@ func (t *Topic) replySetDesc(sess *Session, asUid types.Uid, set *MsgClientSet) 
 			} else {
 				// Notify all subscribers on 'me' except the user who made the change.
 				// He will be notified separately (see below).
-				t.presSubsOffline("upd", nilPresParams,
-					&presFilters{excludeUser: asUid.UserId()}, nilPresFilters,
-					sess.sid, false)
+				filter := &presFilters{excludeUser: asUid.UserId()}
+				t.presSubsOffline("upd", nilPresParams, filter, filter, sess.sid, false)
 			}
 
 			t.updated = now

--- a/server/topic.go
+++ b/server/topic.go
@@ -2484,7 +2484,7 @@ func (t *Topic) evictUser(uid types.Uid, unsub bool, skip string) {
 // 2. Deleted subscription
 // 3. Permissions changed
 // Sending to
-// (a) Topic admis online on topic itself.
+// (a) Topic admins online on topic itself.
 // (b) Topic admins offline on 'me' if approval is needed.
 // (c) If subscription is deleted, 'gone' to target.
 // (d) 'off' to topic members online if deleted or muted.


### PR DESCRIPTION
`filter` argument in `presSubsOffline()` applies to the source topic (the topic from which the presence messages originates).
The target topics to which the message is broadcast may have different filters. Use a separate filter for it.

Example:
Publishing a message on a P2P topic sends presence message to offline users with the `R` filter (https://github.com/tinode/chat/blob/devel/server/topic.go#L340).
While the message passes the P2P topic's filtering, the target `me` topics have default `JPS` acs which the `R` filter will not pass.