### PR TITLE
Topic Proxy: track the list of uid proxied by proxy sessions

### DIFF
--- a/server/cluster.go
+++ b/server/cluster.go
@@ -1262,7 +1262,6 @@ func (c *Cluster) garbageCollectProxySessions(activeNodes []string) {
 // for a leaving proxy session.
 func (sess *Session) cleanUpRemoteSessions(topicName string) {
 	sess.remoteSessionsLock.Lock()
-	defer sess.remoteSessionsLock.Unlock()
 	uidCounts := make(map[types.Uid]int)
 	for _, rs := range sess.remoteSessions {
 		if !rs.isBackground {
@@ -1270,6 +1269,7 @@ func (sess *Session) cleanUpRemoteSessions(topicName string) {
 			uidCounts[rs.uid]++
 		}
 	}
+	sess.remoteSessionsLock.Unlock()
 	if t := globals.hub.topicGet(topicName); t != nil {
 		t.master <- &topicMasterRequest{proxySessionCleanUp: uidCounts}
 	} else {

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -1311,7 +1311,7 @@ func (sess *Session) topicProxyWriteLoop(forTopic string) {
 					}
 					response.ProxyResp.Uid = types.ParseUserId(srvMsg.sessOverrides.cliMsg.asUser)
 					sess.addRemoteSession(srvMsg.sessOverrides.sid, &remoteSession{
-						uid: response.ProxyResp.Uid,
+						uid:          response.ProxyResp.Uid,
 						isBackground: response.ProxyResp.IsBackground})
 				case *ProxyLeave:
 					response.ProxyResp.OrigRequestType = ProxyRequestLeave

--- a/server/hub.go
+++ b/server/hub.go
@@ -199,7 +199,7 @@ func (h *Hub) run() {
 					} else {
 						// It's a master topic. Make a channel for handling
 						// direct messages from the proxy.
-						t.master = make(chan interface{}, 8)
+						t.master = make(chan *topicMasterRequest, 8)
 					}
 				}
 				// Topic is created in suspended state because it's not yet configured.

--- a/server/session.go
+++ b/server/session.go
@@ -138,9 +138,8 @@ type Subscription struct {
 
 func (s *Session) addSub(topic string, sub *Subscription) {
 	s.subsLock.Lock()
-	defer s.subsLock.Unlock()
-
 	s.subs[topic] = sub
+	s.subsLock.Unlock()
 }
 
 func (s *Session) getSub(topic string) *Subscription {
@@ -152,9 +151,8 @@ func (s *Session) getSub(topic string) *Subscription {
 
 func (s *Session) delSub(topic string) {
 	s.subsLock.Lock()
-	defer s.subsLock.Unlock()
-
 	delete(s.subs, topic)
+	s.subsLock.Unlock()
 }
 
 func (s *Session) countSub() int {
@@ -183,14 +181,14 @@ type remoteSession struct {
 
 func (s *Session) addRemoteSession(sid string, rs *remoteSession) {
 	s.remoteSessionsLock.Lock()
-	defer s.remoteSessionsLock.Unlock()
 	s.remoteSessions[sid] = rs
+	s.remoteSessionsLock.Unlock()
 }
 
 func (s *Session) delRemoteSession(sid string) {
 	s.remoteSessionsLock.Lock()
-	defer s.remoteSessionsLock.Unlock()
 	delete(s.remoteSessions, sid)
+	s.remoteSessionsLock.Unlock()
 }
 
 // Indicates whether this session is used as a local interface for a remote proxy topic.

--- a/server/session.go
+++ b/server/session.go
@@ -176,9 +176,9 @@ func (s *Session) unsubAll() {
 // Represents a proxied (remote) session.
 type remoteSession struct {
 	// User id of the proxied session.
-  uid types.Uid
+	uid types.Uid
 	// Whether the proxied session is background.
-  isBackground bool
+	isBackground bool
 }
 
 func (s *Session) addRemoteSession(sid string, rs *remoteSession) {

--- a/server/sessionstore.go
+++ b/server/sessionstore.go
@@ -74,9 +74,9 @@ func (ss *SessionStore) NewSession(conn interface{}, sid string) (*Session, int)
 		s.stop = make(chan interface{}, 1)                 // Buffered by 1 just to make it non-blocking
 		s.detach = make(chan string, 64)                   // buffered
 
-		if globals.cluster != nil && s.proto != CLUSTER {
+		if s.proto == CLUSTER {
 			// This is only useful when running as a cluster and only for non-proxied sessions.
-			s.remoteSubs = make(map[string]*RemoteSubscription)
+			s.remoteSessions = make(map[string]types.Uid)
 		}
 	}
 

--- a/server/sessionstore.go
+++ b/server/sessionstore.go
@@ -75,8 +75,7 @@ func (ss *SessionStore) NewSession(conn interface{}, sid string) (*Session, int)
 		s.detach = make(chan string, 64)                   // buffered
 
 		if s.proto == CLUSTER {
-			// This is only useful when running as a cluster and only for non-proxied sessions.
-			s.remoteSessions = make(map[string]types.Uid)
+			s.remoteSessions = make(map[string]*remoteSession)
 		}
 	}
 


### PR DESCRIPTION
This PR repurposes the no longer used Session.remoteSubs to keep track
of the proxied uids.

Also add some cleanup to make sure perUser accounting on the master topic
remains consistent in case the node hosting the proxy topic goes down.