### PR TITLE
On rehashing, shut down proxy topics when the master moves in.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,19 +1,27 @@
-# If you are not reporting a bug or requesting a feature, please post to https://groups.google.com/d/forum/tinode instead.
+---
+name: Bug report
+about: Create a report to help us improve Tinode
+title: ''
+labels: 'bug'
+assignees: ''
+
+---
+
+**If you are not reporting a bug, please post to https://groups.google.com/d/forum/tinode instead.**
+---
 
 ### Subject of the issue
 Describe your issue here.
 
-### Is this a bug report of a feature request?
-- [ ] Bug report
-- [ ] Feature request
-
 ### Your environment
 #### Server-side
-- [ ] api.tinode.co
+- [ ] web.tinode.co, api.tinode.co
+- [ ] sandbox.tinode.co
 - [ ] Your own setup:
   * platform (Windows, Mac, Linux etc)
-  * version of tinode server, e.g. `0.15.2-rc3`
+  * version of Tinode server, e.g. `0.15.2-rc3`
   * database backend
+  * cluster or standalone
 
 #### Client-side
 - [ ] TinodeWeb/tinodejs: javascript client
@@ -21,11 +29,19 @@ Describe your issue here.
 - [ ] Tindroid: Android app
   * Android API level (e.g. 25).
   * Emulator or hardware, if hardware describe it.
+- [ ] Tinodios: iOS app
+  * iOS version
+  * Simulator or hardware, if hardware describe it.
 - [ ] tn-cli
   * Python version
 - [ ] Chatbot
   * Python version
 - Version of the client, e.g. `0.15.1`
+- [ ] Your own client. Describe it:
+  * Transport (gRPC, websocket, long polling)
+  * Programming language.
+  * gRPC version, if applicable.
+
 
 ### Steps to reproduce
 Tell us how to reproduce this issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: 'feature request'
+assignees: ''
+
+---
+
+**If you are not requesting a feature, please post to https://groups.google.com/d/forum/tinode instead.**
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/server/hub.go
+++ b/server/hub.go
@@ -278,11 +278,17 @@ func (h *Hub) run() {
 			}
 
 		case <-h.rehash:
-			// Cluster rehashing. Some previously local topics became remote.
+			// Cluster rehashing. Some previously local topics became remote,
+			// and the other way round.
 			// Such topics must be shut down at this node.
 			h.topics.Range(func(_, t interface{}) bool {
 				topic := t.(*Topic)
-				if !topic.isProxy && globals.cluster.isRemoteTopic(topic.name) {
+				// Handle two cases:
+				// 1. Master topic has moved out to another node.
+				// 2. Proxy topic is running on a new master node
+				//    (i.e. the master topic has moved to this node).
+				isRemote := globals.cluster.isRemoteTopic(topic.name)
+				if (!topic.isProxy && isRemote) || (topic.isProxy && !isRemote) {
 					h.topicUnreg(nil, topic.name, nil, StopRehashing)
 				}
 				return true

--- a/server/push/fcm/payload.go
+++ b/server/push/fcm/payload.go
@@ -102,6 +102,19 @@ func (ac *AndroidConfig) getColor(what string) string {
 	return color
 }
 
+func (ac *AndroidConfig) getClickAction(what string) string {
+	var clickAction string
+	if what == push.ActMsg {
+		clickAction = ac.Msg.ClickAction
+	} else if what == push.ActSub {
+		clickAction = ac.Sub.ClickAction
+	}
+	if clickAction == "" {
+		clickAction = ac.androidPayload.ClickAction
+	}
+	return clickAction
+}
+
 // Payload to be sent for a specific notification type.
 type androidPayload struct {
 	TitleLocKey string `json:"title_loc_key,omitempty"`
@@ -198,7 +211,7 @@ func PrepareNotifications(rcpt *push.Receipt, config *AndroidConfig) []MessageDa
 		return nil
 	}
 
-	var titlelc, title, bodylc, body, icon, color string
+	var titlelc, title, bodylc, body, icon, color, clickAction string
 	if config != nil && config.Enabled {
 		titlelc = config.getTitleLocKey(rcpt.Payload.What)
 		title = config.getTitle(rcpt.Payload.What)
@@ -209,6 +222,7 @@ func PrepareNotifications(rcpt *push.Receipt, config *AndroidConfig) []MessageDa
 		}
 		icon = config.getIcon(rcpt.Payload.What)
 		color = config.getColor(rcpt.Payload.What)
+		clickAction = config.getClickAction(rcpt.Payload.What)
 	}
 
 	var messages []MessageData
@@ -247,6 +261,7 @@ func PrepareNotifications(rcpt *push.Receipt, config *AndroidConfig) []MessageDa
 							Body:        body,
 							Icon:        icon,
 							Color:       color,
+							ClickAction: clickAction,
 						}
 					}
 				} else if d.Platform == "ios" {


### PR DESCRIPTION
This is to handle the following situation:
upon rehasing event, the topic master moves to another node
which already hosts its proxy. The proxy needs to be shutdown.