### PR TITLE
On rehashing, shut down proxy topics when the master moves in.

### DIFF
--- a/server/hub.go
+++ b/server/hub.go
@@ -287,8 +287,7 @@ func (h *Hub) run() {
 				// 1. Master topic has moved out to another node.
 				// 2. Proxy topic is running on a new master node
 				//    (i.e. the master topic has moved to this node).
-				isRemote := globals.cluster.isRemoteTopic(topic.name)
-				if (!topic.isProxy && isRemote) || (topic.isProxy && !isRemote) {
+				if topic.isProxy != globals.cluster.isRemoteTopic(topic.name) {
 					h.topicUnreg(nil, topic.name, nil, StopRehashing)
 				}
 				return true

--- a/server/hub.go
+++ b/server/hub.go
@@ -278,11 +278,17 @@ func (h *Hub) run() {
 			}
 
 		case <-h.rehash:
-			// Cluster rehashing. Some previously local topics became remote.
+			// Cluster rehashing. Some previously local topics became remote,
+			// and the other way round.
 			// Such topics must be shut down at this node.
 			h.topics.Range(func(_, t interface{}) bool {
 				topic := t.(*Topic)
-				if !topic.isProxy && globals.cluster.isRemoteTopic(topic.name) {
+				// Handle two cases:
+				// 1. Master topic has moved out to another node.
+				// 2. Proxy topic is running on a new master node
+				//    (i.e. the master topic has moved to this node).
+				isRemote := globals.cluster.isRemoteTopic(topic.name)
+				if (!topic.isProxy && isRemote) || (topic.isProxy && !isRemote) {
 					h.topicUnreg(nil, topic.name, nil, StopRehashing)
 				}
 				return true


### PR DESCRIPTION
This is to handle the following situation:
upon rehasing event, the topic master moves to another node
which already hosts its proxy. The proxy needs to be shutdown.