### PR TITLE
Disambiguation and flattening out data structures

### DIFF
--- a/server/cluster.go
+++ b/server/cluster.go
@@ -548,10 +548,9 @@ func (c *Cluster) TopicMaster(msg *ClusterReq, rejected *bool) error {
 			log.Println("join setting uid = ", uid)
 			msg.CliMsg.asUser = uid.UserId()
 		}
-		msg.CliMsg.topic = msg.CliMsg.Sub.Topic
+		msg.CliMsg.original = msg.CliMsg.Sub.Topic
 		msg.CliMsg.id = msg.CliMsg.Sub.Id
 		sessionJoin := &sessionJoin{
-			topic:    msg.RcptTo,
 			pkt:      msg.CliMsg,
 			sess:     sess,
 			created:  msg.TopicMsg.JoinReq.Created,
@@ -596,13 +595,13 @@ func (c *Cluster) TopicMaster(msg *ClusterReq, rejected *bool) error {
 		switch {
 		case msg.CliMsg.Get != nil:
 			msg.CliMsg.id = msg.CliMsg.Get.Id
-			msg.CliMsg.topic = msg.CliMsg.Get.Topic
+			msg.CliMsg.original = msg.CliMsg.Get.Topic
 		case msg.CliMsg.Set != nil:
 			msg.CliMsg.id = msg.CliMsg.Set.Id
-			msg.CliMsg.topic = msg.CliMsg.Set.Topic
+			msg.CliMsg.original = msg.CliMsg.Set.Topic
 		case msg.CliMsg.Del != nil:
 			msg.CliMsg.id = msg.CliMsg.Del.Id
-			msg.CliMsg.topic = msg.CliMsg.Del.Topic
+			msg.CliMsg.original = msg.CliMsg.Del.Topic
 		default:
 			log.Panic("cluster: topic proxy meta request must container either Get or Set field")
 		}

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -559,10 +559,11 @@ func (c *Cluster) TopicMaster(msg *ClusterReq, rejected *bool) error {
 			internal: msg.TopicMsg.JoinReq.Internal,
 			// Impersonate the original session.
 			sessOverrides: &sessionOverrides{
-				sid:     origSid,
-				rcptTo:  msg.RcptTo,
-				origReq: msg.TopicMsg.JoinReq,
-				cliMsg:  msg.CliMsg,
+				sid:          origSid,
+				rcptTo:       msg.RcptTo,
+				origReq:      msg.TopicMsg.JoinReq,
+				asUser:       msg.CliMsg.asUser,
+				isBackground: msg.CliMsg.Sub.Background,
 			},
 		}
 		globals.hub.join <- sessionJoin
@@ -1288,10 +1289,8 @@ func (sess *Session) topicProxyWriteLoop(forTopic string) {
 					panic("cluster: origReq is nil in session overrides")
 				case *ProxyJoin:
 					response.ProxyResp.OrigRequestType = ProxyRequestJoin
-					if srvMsg.sessOverrides.cliMsg.Sub.Background {
-						response.ProxyResp.IsBackground = true
-					}
-					response.ProxyResp.Uid = types.ParseUserId(srvMsg.sessOverrides.cliMsg.asUser)
+					response.ProxyResp.IsBackground = srvMsg.sessOverrides.isBackground
+					response.ProxyResp.Uid = types.ParseUserId(srvMsg.sessOverrides.asUser)
 					sess.addRemoteSession(srvMsg.sessOverrides.sid, &remoteSession{
 						uid:          response.ProxyResp.Uid,
 						isBackground: response.ProxyResp.IsBackground})

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -114,7 +114,7 @@ type ClusterReq struct {
 	SrvMsg *ServerComMessage
 	// Topic message.
 	// Set for topic proxy to topic master requests.
-	TopicMsg *ProxyTopicData
+	TopicMsg *ProxyTopicMessage
 
 	// Root user may send messages on behalf of other users.
 	OnBehalfOf string
@@ -138,12 +138,21 @@ type ClusterResp struct {
 	FromSID string
 	// Expanded (routable) topic name
 	RcptTo string
-	// Response to a topic proxy request.
-	ProxyResp *ProxyResponse
+
+	// Various parameters sent back by the topic master in response a topic proxy request.
+
+	// Request type.
+	OrigRequestType int
+	// SessionID to skip. Set for broadcast requests.
+	SkipSid string
+	// ID of the affected user.
+	Uid types.Uid
+	// It is a response to a request from a background session.
+	IsBackground bool
 }
 
-// ProxyTopicData combines topic proxy to master request params.
-type ProxyTopicData struct {
+// ProxyTopicMessage combines topic proxy to master request params.
+type ProxyTopicMessage struct {
 	// Join (subscribe) request.
 	JoinReq *ProxyJoin
 	// Broadcast (publish, etc.) request.
@@ -230,18 +239,6 @@ const (
 	ProxyRequestMeta      = 3
 	ProxyRequestBroadcast = 4
 )
-
-// ProxyResponse contains various parameters sent back by the topic master in response a topic proxy request.
-type ProxyResponse struct {
-	// Request type.
-	OrigRequestType int
-	// SessionID to skip. Set for broadcast requests.
-	SkipSid string
-	// User id of the affected user.
-	Uid types.Uid
-	// It is a response to a request from a background session.
-	IsBackground bool
-}
 
 // Handle outbound node communication: read messages from the channel, forward to remote nodes.
 // FIXME(gene): this will drain the outbound queue in case of a failure: all unprocessed messages will be dropped.
@@ -548,8 +545,9 @@ func (c *Cluster) TopicMaster(msg *ClusterReq, rejected *bool) error {
 			log.Println("join setting uid = ", uid)
 			msg.CliMsg.asUser = uid.UserId()
 		}
-		msg.CliMsg.original = msg.CliMsg.Sub.Topic
-		msg.CliMsg.id = msg.CliMsg.Sub.Id
+		pktsub := msg.CliMsg.Sub
+		msg.CliMsg.original = pktsub.Topic
+		msg.CliMsg.id = pktsub.Id
 		sessionJoin := &sessionJoin{
 			pkt:      msg.CliMsg,
 			sess:     sess,
@@ -562,7 +560,7 @@ func (c *Cluster) TopicMaster(msg *ClusterReq, rejected *bool) error {
 				rcptTo:       msg.RcptTo,
 				origReq:      msg.TopicMsg.JoinReq,
 				asUser:       msg.CliMsg.asUser,
-				isBackground: msg.CliMsg.Sub.Background,
+				isBackground: pktsub.Background,
 			},
 		}
 		globals.hub.join <- sessionJoin
@@ -896,7 +894,7 @@ func (c *Cluster) isPartitioned() bool {
 }
 
 func (c *Cluster) getClusterReq(cliMsg *ClientComMessage, srvMsg *ServerComMessage,
-	topicMsg *ProxyTopicData, topic string, sess *Session) *ClusterReq {
+	topicMsg *ProxyTopicMessage, topic string, sess *Session) *ClusterReq {
 	req := &ClusterReq{
 		Node:        c.thisNodeName,
 		Signature:   c.ring.Signature(),
@@ -928,7 +926,7 @@ func (c *Cluster) getClusterReq(cliMsg *ClientComMessage, srvMsg *ServerComMessa
 
 // Forward client request message from the Topic Proxy to the Topic Master (cluster node which owns the topic)
 func (c *Cluster) routeToTopicMaster(cliMsg *ClientComMessage, srvMsg *ServerComMessage,
-	topicMsg *ProxyTopicData, topic string, sess *Session) error {
+	topicMsg *ProxyTopicMessage, topic string, sess *Session) error {
 	// Find the cluster node which owns the topic, then forward to it.
 	n := c.nodeForTopic(topic)
 	if n == nil {
@@ -1277,34 +1275,31 @@ func (sess *Session) topicProxyWriteLoop(forTopic string) {
 			}
 			srvMsg := msg.(*ServerComMessage)
 
-			response := &ClusterResp{
-				SrvMsg:    srvMsg,
-				ProxyResp: &ProxyResponse{},
-			}
+			response := &ClusterResp{SrvMsg: srvMsg}
 			copyParamsFromSession := false
 			if srvMsg.sessOverrides != nil {
 				switch req := srvMsg.sessOverrides.origReq.(type) {
 				case nil:
 					panic("cluster: origReq is nil in session overrides")
 				case *ProxyJoin:
-					response.ProxyResp.OrigRequestType = ProxyRequestJoin
-					response.ProxyResp.IsBackground = srvMsg.sessOverrides.isBackground
-					response.ProxyResp.Uid = types.ParseUserId(srvMsg.sessOverrides.asUser)
+					response.OrigRequestType = ProxyRequestJoin
+					response.IsBackground = srvMsg.sessOverrides.isBackground
+					response.Uid = types.ParseUserId(srvMsg.sessOverrides.asUser)
 					sess.addRemoteSession(srvMsg.sessOverrides.sid, &remoteSession{
-						uid:          response.ProxyResp.Uid,
-						isBackground: response.ProxyResp.IsBackground})
+						uid:          response.Uid,
+						isBackground: response.IsBackground})
 				case *ProxyLeave:
-					response.ProxyResp.OrigRequestType = ProxyRequestLeave
+					response.OrigRequestType = ProxyRequestLeave
 					sess.delRemoteSession(srvMsg.sessOverrides.sid)
 					if req.TerminateProxyConnection {
 						log.Printf("session [%s]: terminating upon client request", srvMsg.sessOverrides.sid)
 						sess.detach <- forTopic
 					}
 				case *ProxyBroadcast:
-					response.ProxyResp.OrigRequestType = ProxyRequestBroadcast
-					response.ProxyResp.SkipSid = req.SkipSid
+					response.OrigRequestType = ProxyRequestBroadcast
+					response.SkipSid = req.SkipSid
 				case *ProxyMeta:
-					response.ProxyResp.OrigRequestType = ProxyRequestMeta
+					response.OrigRequestType = ProxyRequestMeta
 				}
 				copyParamsFromSession = srvMsg.sessOverrides.sid != ""
 			} else {
@@ -1313,8 +1308,8 @@ func (sess *Session) topicProxyWriteLoop(forTopic string) {
 					// Only broadcast messages (data, pres, info) may come not as a response to a client request.
 					log.Panicf("cluster: only broadcast messages may not contain session overrides: %+v", srvMsg)
 				}
-				response.ProxyResp.SkipSid = srvMsg.skipSid
-				response.ProxyResp.Uid = srvMsg.uid
+				response.SkipSid = srvMsg.skipSid
+				response.Uid = srvMsg.uid
 			}
 			if copyParamsFromSession {
 				// Reply to a specific session.

--- a/server/datamodel.go
+++ b/server/datamodel.go
@@ -500,13 +500,13 @@ type MsgServerPres struct {
 	// skip those who have this access mode.
 	FilterOut int `json:"-"`
 
-	// When sending to 'me', skip sessions subscribed to this topic
+	// When sending to 'me', skip sessions subscribed to this topic.
 	SkipTopic string `json:"-"`
 
-	// Send to sessions of a single user only
+	// Send to sessions of a single user only.
 	SingleUser string `json:"-"`
 
-	// Exclude sessions of a single user
+	// Exclude sessions of a single user.
 	ExcludeUser string `json:"-"`
 }
 

--- a/server/datamodel.go
+++ b/server/datamodel.go
@@ -567,8 +567,10 @@ type sessionOverrides struct {
 	userAgent string
 	// Incoming proxy topic request pointer. Set for topic proxy requests.
 	origReq interface{}
-	// Original client request.
-	cliMsg *ClientComMessage
+	// User represented by this session.
+	asUser string
+	// The session was a background session.
+	isBackground bool
 }
 
 // Deep copy

--- a/server/datamodel.go
+++ b/server/datamodel.go
@@ -310,7 +310,9 @@ type ClientComMessage struct {
 	// Message ID denormalized
 	id string
 	// Un-routable (original) topic name denormalized from XXX.Topic.
-	topic string
+	original string
+	// Routable (expanded) topic name
+	rcptTo string
 	// Sender's UserId as string
 	asUser string
 	// Sender's authentication level
@@ -561,15 +563,16 @@ type MsgServerInfo struct {
 type sessionOverrides struct {
 	// Proxied session id.
 	sid string
-	// Topic id the session represents.
+	// Topic name affected by the original request.
 	rcptTo string
 	// User agent of the original session.
 	userAgent string
-	// Incoming proxy topic request pointer. Set for topic proxy requests.
+	// Incoming proxy topic request pointer. Set for topic proxy requests. One of
+	// *ProxyJoin, *ProxyLeave, *ProxyBroadcast, *ProxyMeta.
 	origReq interface{}
 	// User represented by this session.
 	asUser string
-	// The session was a background session.
+	// The original request was a background subscription.
 	isBackground bool
 }
 
@@ -592,9 +595,9 @@ type ServerComMessage struct {
 
 	// MsgServerData has no Id field, copying it here for use in {ctrl} aknowledgements
 	id string
-	// to: topic
+	// Routable (expanded) name of the topic.
 	rcptto string
-	// timestamp for consistency of timestamps in {ctrl} messages
+	// Timestamp for consistency of timestamps in {ctrl} messages
 	timestamp time.Time
 	// User ID of the sender of the original message.
 	asUser string

--- a/server/hub.go
+++ b/server/hub.go
@@ -25,15 +25,16 @@ import (
 type sessionJoin struct {
 	// Packet, containing request details.
 	pkt *ClientComMessage
-	// Session to subscribe.
+	// Session to attach to topic.
 	sess *Session
-	// True if this topic was just created.
+
+	// True if this subscription created a new topic.
 	// In case of p2p topics, it's true if the other user's subscription was
 	// created (as a part of new topic creation or just alone).
 	created bool
 	// True if this is a new subscription.
 	newsub bool
-	// True if this topic is created internally.
+	// True if this is an internal request.
 	internal bool
 
 	// Session param overrides. Used for handling remote topic requests.

--- a/server/hub.go
+++ b/server/hub.go
@@ -23,8 +23,6 @@ import (
 
 // Request to hub to subscribe session to topic
 type sessionJoin struct {
-	// Routable (expanded) name of the topic to subscribe to.
-	topic string
 	// Packet, containing request details.
 	pkt *ClientComMessage
 	// Session to subscribe.
@@ -154,7 +152,7 @@ func newHub() *Hub {
 
 	if !globals.cluster.isRemoteTopic("sys") {
 		// Initialize system 'sys' topic. There is only one sys topic per cluster.
-		h.join <- &sessionJoin{topic: "sys", internal: true, pkt: &ClientComMessage{topic: "sys"}}
+		h.join <- &sessionJoin{internal: true, pkt: &ClientComMessage{rcptTo: "sys", original: "sys"}}
 	}
 
 	return h
@@ -176,13 +174,13 @@ func (h *Hub) run() {
 			// 3. Attach session to the topic
 
 			// Is the topic already loaded?
-			t := h.topicGet(sreg.topic)
+			t := h.topicGet(sreg.pkt.rcptTo)
 			if t == nil {
 				// Topic does not exist or not loaded.
-				t = &Topic{name: sreg.topic,
-					xoriginal: sreg.pkt.topic,
+				t = &Topic{name: sreg.pkt.rcptTo,
+					xoriginal: sreg.pkt.original,
 					// Indicates a proxy topic.
-					isProxy:   globals.cluster.isRemoteTopic(sreg.topic),
+					isProxy:   globals.cluster.isRemoteTopic(sreg.pkt.rcptTo),
 					sessions:  make(map[*Session]perSessionData),
 					broadcast: make(chan *ServerComMessage, 256),
 					reg:       make(chan *sessionJoin, 32),
@@ -205,7 +203,7 @@ func (h *Hub) run() {
 				// Topic is created in suspended state because it's not yet configured.
 				t.markPaused(true)
 				// Save topic now to prevent race condition.
-				h.topicPut(sreg.topic, t)
+				h.topicPut(sreg.pkt.rcptTo, t)
 
 				// Configure the topic.
 				go topicInit(t, sreg, h)
@@ -298,7 +296,7 @@ func (h *Hub) run() {
 				// Yes, 'sys' has migrated here. Initialize it.
 				// The h.join is unbuffered. We must call from another goroutine. Otherwise deadlock.
 				go func() {
-					h.join <- &sessionJoin{topic: "sys", internal: true, pkt: &ClientComMessage{topic: "sys"}}
+					h.join <- &sessionJoin{internal: true, pkt: &ClientComMessage{rcptTo: "sys", original: "sys"}}
 				}()
 			}
 
@@ -389,11 +387,11 @@ func (h *Hub) topicUnreg(sess *Session, topic string, msg *ClientComMessage, rea
 				t.markPaused(true)
 				if err := store.Topics.Delete(topic, msg.Del.Hard); err != nil {
 					t.markPaused(false)
-					sess.queueOut(ErrUnknown(msg.id, msg.topic, now))
+					sess.queueOut(ErrUnknown(msg.id, msg.original, now))
 					return err
 				}
 
-				sess.queueOut(NoErr(msg.id, msg.topic, now))
+				sess.queueOut(NoErr(msg.id, msg.original, now))
 
 				h.topicDel(topic)
 				t.markDeleted()
@@ -415,12 +413,12 @@ func (h *Hub) topicUnreg(sess *Session, topic string, msg *ClientComMessage, rea
 			// Get all subscribers: we need to know how many are left and notify them.
 			subs, err := store.Topics.GetSubs(topic, nil)
 			if err != nil {
-				sess.queueOut(ErrUnknown(msg.id, msg.topic, now))
+				sess.queueOut(ErrUnknown(msg.id, msg.original, now))
 				return err
 			}
 
 			if len(subs) == 0 {
-				sess.queueOut(InfoNoAction(msg.id, msg.topic, now))
+				sess.queueOut(InfoNoAction(msg.id, msg.original, now))
 				return nil
 			}
 
@@ -435,7 +433,7 @@ func (h *Hub) topicUnreg(sess *Session, topic string, msg *ClientComMessage, rea
 
 			if sub == nil {
 				// If user has no subscription, tell him all is fine
-				sess.queueOut(InfoNoAction(msg.id, msg.topic, now))
+				sess.queueOut(InfoNoAction(msg.id, msg.original, now))
 				return nil
 			}
 
@@ -446,7 +444,7 @@ func (h *Hub) topicUnreg(sess *Session, topic string, msg *ClientComMessage, rea
 				if tcat == types.TopicCatP2P && len(subs) < 2 {
 					// This is a P2P topic and fewer than 2 subscriptions, delete the entire topic
 					if err := store.Topics.Delete(topic, msg.Del.Hard); err != nil {
-						sess.queueOut(ErrUnknown(msg.id, msg.topic, now))
+						sess.queueOut(ErrUnknown(msg.id, msg.original, now))
 						return err
 					}
 
@@ -454,19 +452,19 @@ func (h *Hub) topicUnreg(sess *Session, topic string, msg *ClientComMessage, rea
 					// Not P2P or more than 1 subscription left.
 					// Delete user's own subscription only
 					if err == types.ErrNotFound {
-						sess.queueOut(InfoNoAction(msg.id, msg.topic, now))
+						sess.queueOut(InfoNoAction(msg.id, msg.original, now))
 						err = nil
 					} else {
-						sess.queueOut(ErrUnknown(msg.id, msg.topic, now))
+						sess.queueOut(ErrUnknown(msg.id, msg.original, now))
 					}
 					return err
 				}
 
 				// Notify user's other sessions that the subscription is gone
-				presSingleUserOfflineOffline(asUid, msg.topic, "gone", nilPresParams, sess.sid)
+				presSingleUserOfflineOffline(asUid, msg.original, "gone", nilPresParams, sess.sid)
 				if tcat == types.TopicCatP2P && len(subs) == 2 {
 					uname1 := asUid.UserId()
-					uid2 := types.ParseUserId(msg.topic)
+					uid2 := types.ParseUserId(msg.original)
 					// Tell user1 to stop sending updates to user2 without passing change to user1's sessions.
 					presSingleUserOfflineOffline(asUid, uid2.UserId(), "?none+rem", nilPresParams, "")
 					// Don't change the online status of user1, just ask user2 to stop notification exchange.
@@ -478,15 +476,15 @@ func (h *Hub) topicUnreg(sess *Session, topic string, msg *ClientComMessage, rea
 				// Case 1.2.1.1: owner, delete the group topic from db.
 				// Only group topics have owners.
 				if err := store.Topics.Delete(topic, msg.Del.Hard); err != nil {
-					sess.queueOut(ErrUnknown(msg.id, msg.topic, now))
+					sess.queueOut(ErrUnknown(msg.id, msg.original, now))
 					return err
 				}
 
 				// Notify subscribers that the group topic is gone.
-				presSubsOfflineOffline(msg.topic, tcat, subs, "gone", &presParams{}, sess.sid)
+				presSubsOfflineOffline(msg.original, tcat, subs, "gone", &presParams{}, sess.sid)
 			}
 
-			sess.queueOut(NoErr(msg.id, msg.topic, now))
+			sess.queueOut(NoErr(msg.id, msg.original, now))
 		}
 
 	} else {
@@ -503,7 +501,7 @@ func (h *Hub) topicUnreg(sess *Session, topic string, msg *ClientComMessage, rea
 
 		// sess && msg could be nil if the topic is being killed by timer or due to rehashing.
 		if sess != nil && msg != nil {
-			sess.queueOut(NoErr(msg.id, msg.topic, now))
+			sess.queueOut(NoErr(msg.id, msg.original, now))
 		}
 	}
 
@@ -563,11 +561,11 @@ func replyOfflineTopicGetDesc(sess *Session, topic string, msg *ClientComMessage
 		stopic, err := store.Topics.Get(topic)
 		if err != nil {
 			log.Println("replyOfflineTopicGetDesc", err)
-			sess.queueOut(decodeStoreError(err, msg.id, msg.topic, now, nil))
+			sess.queueOut(decodeStoreError(err, msg.id, msg.original, now, nil))
 			return
 		}
 		if stopic == nil {
-			sess.queueOut(ErrTopicNotFound(msg.id, msg.topic, now))
+			sess.queueOut(ErrTopicNotFound(msg.id, msg.original, now))
 			return
 		}
 
@@ -599,17 +597,17 @@ func replyOfflineTopicGetDesc(sess *Session, topic string, msg *ClientComMessage
 
 		if uid.IsZero() {
 			log.Println("replyOfflineTopicGetDesc: malformed p2p topic name")
-			sess.queueOut(ErrMalformed(msg.id, msg.topic, now))
+			sess.queueOut(ErrMalformed(msg.id, msg.original, now))
 			return
 		}
 
 		suser, err := store.Users.Get(uid)
 		if err != nil {
-			sess.queueOut(decodeStoreError(err, msg.id, msg.topic, now, nil))
+			sess.queueOut(decodeStoreError(err, msg.id, msg.original, now, nil))
 			return
 		}
 		if suser == nil {
-			sess.queueOut(ErrUserNotFound(msg.id, msg.topic, now))
+			sess.queueOut(ErrUserNotFound(msg.id, msg.original, now))
 			return
 		}
 		desc.CreatedAt = &suser.CreatedAt
@@ -623,7 +621,7 @@ func replyOfflineTopicGetDesc(sess *Session, topic string, msg *ClientComMessage
 	sub, err := store.Subs.Get(topic, asUid)
 	if err != nil {
 		log.Println("replyOfflineTopicGetDesc:", err)
-		sess.queueOut(decodeStoreError(err, msg.id, msg.topic, now, nil))
+		sess.queueOut(decodeStoreError(err, msg.id, msg.original, now, nil))
 		return
 	}
 
@@ -637,7 +635,7 @@ func replyOfflineTopicGetDesc(sess *Session, topic string, msg *ClientComMessage
 	}
 
 	sess.queueOut(&ServerComMessage{
-		Meta: &MsgServerMeta{Id: msg.id, Topic: msg.topic, Timestamp: &now, Desc: desc}})
+		Meta: &MsgServerMeta{Id: msg.id, Topic: msg.original, Timestamp: &now, Desc: desc}})
 }
 
 // replyOfflineTopicGetSub reads user's subscription from the database.
@@ -647,19 +645,19 @@ func replyOfflineTopicGetSub(sess *Session, topic string, msg *ClientComMessage)
 	now := types.TimeNow()
 
 	if msg.Get.Sub != nil && msg.Get.Sub.User != "" && msg.Get.Sub.User != msg.asUser {
-		sess.queueOut(ErrPermissionDenied(msg.id, msg.topic, now))
+		sess.queueOut(ErrPermissionDenied(msg.id, msg.original, now))
 		return
 	}
 
 	ssub, err := store.Subs.Get(topic, types.ParseUserId(msg.asUser))
 	if err != nil {
 		log.Println("replyOfflineTopicGetSub:", err)
-		sess.queueOut(decodeStoreError(err, msg.id, msg.topic, now, nil))
+		sess.queueOut(decodeStoreError(err, msg.id, msg.original, now, nil))
 		return
 	}
 
 	if ssub == nil {
-		sess.queueOut(ErrNotFound(msg.id, msg.topic, now))
+		sess.queueOut(ErrNotFound(msg.id, msg.original, now))
 		return
 	}
 
@@ -684,7 +682,7 @@ func replyOfflineTopicGetSub(sess *Session, topic string, msg *ClientComMessage)
 	}
 
 	sess.queueOut(&ServerComMessage{
-		Meta: &MsgServerMeta{Id: msg.id, Topic: msg.topic, Timestamp: &now, Sub: []MsgTopicSub{sub}}})
+		Meta: &MsgServerMeta{Id: msg.id, Topic: msg.original, Timestamp: &now, Sub: []MsgTopicSub{sub}}})
 }
 
 // replyOfflineTopicSetSub updates Desc.Private and Sub.Mode when the topic is not loaded in memory.
@@ -694,12 +692,12 @@ func replyOfflineTopicSetSub(sess *Session, topic string, msg *ClientComMessage)
 	now := types.TimeNow()
 
 	if (msg.Set.Desc == nil || msg.Set.Desc.Private == nil) && (msg.Set.Sub == nil || msg.Set.Sub.Mode == "") {
-		sess.queueOut(InfoNotModified(msg.id, msg.topic, now))
+		sess.queueOut(InfoNotModified(msg.id, msg.original, now))
 		return
 	}
 
 	if msg.Set.Sub != nil && msg.Set.Sub.User != "" && msg.Set.Sub.User != msg.asUser {
-		sess.queueOut(ErrPermissionDenied(msg.id, msg.topic, now))
+		sess.queueOut(ErrPermissionDenied(msg.id, msg.original, now))
 		return
 	}
 
@@ -708,12 +706,12 @@ func replyOfflineTopicSetSub(sess *Session, topic string, msg *ClientComMessage)
 	sub, err := store.Subs.Get(topic, asUid)
 	if err != nil {
 		log.Println("replyOfflineTopicSetSub get sub:", err)
-		sess.queueOut(decodeStoreError(err, msg.id, msg.topic, now, nil))
+		sess.queueOut(decodeStoreError(err, msg.id, msg.original, now, nil))
 		return
 	}
 
 	if sub == nil || sub.DeletedAt != nil {
-		sess.queueOut(ErrNotFound(msg.id, msg.topic, now))
+		sess.queueOut(ErrNotFound(msg.id, msg.original, now))
 		return
 	}
 
@@ -731,13 +729,13 @@ func replyOfflineTopicSetSub(sess *Session, topic string, msg *ClientComMessage)
 		var modeWant types.AccessMode
 		if err = modeWant.UnmarshalText([]byte(msg.Set.Sub.Mode)); err != nil {
 			log.Println("replyOfflineTopicSetSub mode:", err)
-			sess.queueOut(decodeStoreError(err, msg.id, msg.topic, now, nil))
+			sess.queueOut(decodeStoreError(err, msg.id, msg.original, now, nil))
 			return
 		}
 
 		if modeWant.IsOwner() != sub.ModeWant.IsOwner() {
 			// No ownership changes here.
-			sess.queueOut(ErrPermissionDenied(msg.id, msg.topic, now))
+			sess.queueOut(ErrPermissionDenied(msg.id, msg.original, now))
 			return
 		}
 
@@ -758,7 +756,7 @@ func replyOfflineTopicSetSub(sess *Session, topic string, msg *ClientComMessage)
 		err = store.Subs.Update(topic, asUid, update, true)
 		if err != nil {
 			log.Println("replyOfflineTopicSetSub update:", err)
-			sess.queueOut(decodeStoreError(err, msg.id, msg.topic, now, nil))
+			sess.queueOut(decodeStoreError(err, msg.id, msg.original, now, nil))
 		} else {
 			var params interface{}
 			if update["ModeWant"] != nil {
@@ -767,9 +765,9 @@ func replyOfflineTopicSetSub(sess *Session, topic string, msg *ClientComMessage)
 					Want:  sub.ModeWant.String(),
 					Mode:  (sub.ModeGiven & sub.ModeWant).String()}}
 			}
-			sess.queueOut(NoErrParams(msg.id, msg.topic, now, params))
+			sess.queueOut(NoErrParams(msg.id, msg.original, now, params))
 		}
 	} else {
-		sess.queueOut(InfoNotModified(msg.id, msg.topic, now))
+		sess.queueOut(InfoNotModified(msg.id, msg.original, now))
 	}
 }

--- a/server/init_topic.go
+++ b/server/init_topic.go
@@ -49,9 +49,9 @@ func topicInit(t *Topic, sreg *sessionJoin, h *Hub) {
 	// Failed to create or load the topic.
 	if err != nil {
 		// Remove topic from cache to prevent hub from forwarding more messages to it.
-		h.topicDel(sreg.topic)
+		h.topicDel(sreg.pkt.rcptTo)
 
-		log.Println("hub: failed to load or create topic:", sreg.topic, err)
+		log.Println("hub: failed to load or create topic:", sreg.pkt.rcptTo, err)
 		sreg.sess.queueOutWithOverrides(decodeStoreError(err, sreg.pkt.id, t.xoriginal, timestamp, nil), sreg.sessOverrides)
 
 		// Re-queue pending requests to join the topic.
@@ -85,7 +85,7 @@ func topicInit(t *Topic, sreg *sessionJoin, h *Hub) {
 
 	// prevent newly initialized topics to go live while shutdown in progress
 	if globals.shuttingDown {
-		h.topicDel(sreg.topic)
+		h.topicDel(sreg.pkt.rcptTo)
 		return
 	}
 
@@ -547,7 +547,7 @@ func initTopicNewGrp(t *Topic, sreg *sessionJoin) error {
 	// t.lastId & t.delId are not set for new topics
 
 	stopic := &types.Topic{
-		ObjHeader: types.ObjHeader{Id: sreg.topic, CreatedAt: timestamp},
+		ObjHeader: types.ObjHeader{Id: sreg.pkt.rcptTo, CreatedAt: timestamp},
 		Access:    types.DefaultAccess{Auth: t.accessAuth, Anon: t.accessAnon},
 		Tags:      tags,
 		Public:    t.public}

--- a/server/session.go
+++ b/server/session.go
@@ -916,10 +916,9 @@ func (s *Session) del(msg *ClientComMessage) {
 		// Deleting topic: for sessions attached or not attached, send request to hub first.
 		// Hub will forward to topic, if appropriate.
 		globals.hub.unreg <- &topicUnreg{
-			topic: msg.rcptTo,
-			pkt:   msg,
-			sess:  s,
-			del:   true}
+			pkt:  msg,
+			sess: s,
+			del:  true}
 	} else {
 		// Must join the topic to delete messages or subscriptions.
 		s.queueOut(ErrAttachFirst(msg.id, msg.original, msg.timestamp))

--- a/server/topic.go
+++ b/server/topic.go
@@ -218,7 +218,6 @@ func (t *Topic) runProxy(hub *Hub) {
 				asUid := types.ParseUserId(sreg.pkt.asUser)
 				sreg.sess.queueOut(ErrLocked(sreg.pkt.id, t.original(asUid), types.TimeNow()))
 			} else {
-				log.Printf("topic[%s] reg %+v", t.name, sreg)
 				msg := &ProxyTopicData{
 					JoinReq: &ProxyJoin{
 						Created:  sreg.created,
@@ -226,7 +225,6 @@ func (t *Topic) runProxy(hub *Hub) {
 						Internal: sreg.internal,
 					},
 				}
-				log.Println("sessionJoin pkt = ", sreg.pkt, sreg.topic)
 				// Response (ctrl message) will be handled when it's received via the proxy channel.
 				if err := globals.cluster.routeToTopicMaster(sreg.pkt, nil, msg, t.name, sreg.sess); err != nil {
 					log.Println("proxy topic: route join request from proxy to master failed:", err)
@@ -1363,8 +1361,8 @@ func (t *Topic) subCommonReply(h *Hub, sreg *sessionJoin) error {
 
 	// When a group topic is created, it's given a temporary name by the client.
 	// Then this name changes. Report back the original name here.
-	if sreg.created && sreg.pkt.topic != toriginal {
-		params["tmpname"] = sreg.pkt.topic
+	if sreg.created && sreg.pkt.original != toriginal {
+		params["tmpname"] = sreg.pkt.original
 	}
 
 	if len(params) == 0 {

--- a/server/topic.go
+++ b/server/topic.go
@@ -218,7 +218,7 @@ func (t *Topic) runProxy(hub *Hub) {
 				asUid := types.ParseUserId(sreg.pkt.asUser)
 				sreg.sess.queueOut(ErrLocked(sreg.pkt.id, t.original(asUid), types.TimeNow()))
 			} else {
-				msg := &ProxyTopicData{
+				msg := &ProxyTopicMessage{
 					JoinReq: &ProxyJoin{
 						Created:  sreg.created,
 						Newsub:   sreg.newsub,
@@ -249,7 +249,7 @@ func (t *Topic) runProxy(hub *Hub) {
 			// and we won't be able to find and remove it by its sid.
 			t.remSession(leave.sess, asUid)
 			msg := &ClientComMessage{}
-			proxyLeave := &ProxyTopicData{
+			proxyLeave := &ProxyTopicMessage{
 				LeaveReq: &ProxyLeave{
 					Id:     leave.id,
 					UserId: asUid,
@@ -264,7 +264,7 @@ func (t *Topic) runProxy(hub *Hub) {
 
 		case msg := <-t.broadcast:
 			// Content message intended for broadcasting to recipients
-			brdc := &ProxyTopicData{
+			brdc := &ProxyTopicMessage{
 				BroadcastReq: &ProxyBroadcast{
 					Id:        msg.id,
 					From:      msg.asUser,
@@ -280,7 +280,7 @@ func (t *Topic) runProxy(hub *Hub) {
 		case meta := <-t.meta:
 			// Request to get/set topic metadata
 			log.Printf("t[%s] meta %+v", t.name, meta)
-			req := &ProxyTopicData{
+			req := &ProxyTopicMessage{
 				MetaReq: &ProxyMeta{
 					What: meta.what,
 				},
@@ -291,8 +291,7 @@ func (t *Topic) runProxy(hub *Hub) {
 
 		case ua := <-t.uaChange:
 			// Process an update to user agent from one of the sessions
-			log.Printf("t[%s] uaChange %+v", t.name, ua)
-			req := &ProxyTopicData{
+			req := &ProxyTopicMessage{
 				UAChangeReq: &ProxyUAChange{
 					UserAgent: ua,
 				},
@@ -302,16 +301,14 @@ func (t *Topic) runProxy(hub *Hub) {
 			}
 
 		case msg := <-t.proxy:
-			log.Printf("proxy topic [%s] msg: sid[%s] = %+v | proxyresp = %+v", t.name, msg.FromSID, msg.SrvMsg, msg.ProxyResp)
-
 			if msg.SrvMsg.Pres != nil && msg.SrvMsg.Pres.What == "acs" && msg.SrvMsg.Pres.Acs != nil {
 				// If the server changed acs on this topic, update the internal state.
 				t.updateAcsFromPresMsg(msg.SrvMsg.Pres)
 			}
 			if msg.FromSID == "*" {
 				// It is a broadcast.
-				msg.SrvMsg.skipSid = msg.ProxyResp.SkipSid
-				msg.SrvMsg.uid = msg.ProxyResp.Uid
+				msg.SrvMsg.skipSid = msg.SkipSid
+				msg.SrvMsg.uid = msg.Uid
 				switch {
 				case msg.SrvMsg.Pres != nil || msg.SrvMsg.Data != nil || msg.SrvMsg.Info != nil:
 					// Regular broadcast.
@@ -323,17 +320,17 @@ func (t *Topic) runProxy(hub *Hub) {
 				}
 			} else {
 				sess := globals.sessionStore.Get(msg.FromSID)
-				switch msg.ProxyResp.OrigRequestType {
+				switch msg.OrigRequestType {
 				case ProxyRequestJoin:
 					if sess != nil && msg.SrvMsg != nil && msg.SrvMsg.Ctrl != nil {
 						if msg.SrvMsg.Ctrl.Code < 300 {
-							if t.addSession(sess, msg.ProxyResp.Uid) {
+							if t.addSession(sess, msg.Uid) {
 								sess.addSub(t.name, &Subscription{
 									broadcast: t.broadcast,
 									done:      t.unreg,
 									meta:      t.meta,
 									uaChange:  t.uaChange})
-								if msg.ProxyResp.IsBackground {
+								if msg.IsBackground {
 									// It's a background session.
 									// Make a fake sessionJoin packet and add it to deferred notification list.
 									// We only need a timestamp and a pointer to the session
@@ -341,7 +338,7 @@ func (t *Topic) runProxy(hub *Hub) {
 									sreg := &sessionJoin{
 										sess: sess,
 										pkt: &ClientComMessage{
-											asUser:    msg.ProxyResp.Uid.UserId(),
+											asUser:    msg.Uid.UserId(),
 											timestamp: types.TimeNow(),
 										},
 									}
@@ -374,7 +371,7 @@ func (t *Topic) runProxy(hub *Hub) {
 						}
 					}
 				default:
-					log.Printf("proxy topic [%s] received response referencing unknown request type %d", t.name, msg.ProxyResp.OrigRequestType)
+					log.Printf("proxy topic [%s] received response referencing unknown request type %d", t.name, msg.OrigRequestType)
 				}
 				if !sess.queueOut(msg.SrvMsg) {
 					log.Println("topic proxy: timeout")
@@ -1072,7 +1069,7 @@ func (t *Topic) routeDeferredNotificationsToMaster(joinReqs []*sessionJoin) {
 		}
 		sendReqs = append(sendReqs, s)
 	}
-	msg := &ProxyTopicData{
+	msg := &ProxyTopicMessage{
 		DefrNotifReq: &ProxyDeferredNotifications{
 			SendNotificationRequests: sendReqs,
 		},


### PR DESCRIPTION
* ProxyTopicData may be confused with `{data}` package. Renamed it to `ProxyTopicMessage`.
* `ProxyResponse` merged into `ClusterResponse`.
*  Removed a copy of `ClientComMessage` from `sessionOverrides`. Left only those fields which are actually used instead.
* Renamed `ClientComMessage.topic` to `.original` to disambiguate it from expanded topic name.

