### PR TITLE
More disambiguation and reduced amount of copying

### DIFF
--- a/server/cluster.go
+++ b/server/cluster.go
@@ -545,9 +545,6 @@ func (c *Cluster) TopicMaster(msg *ClusterReq, rejected *bool) error {
 			msg.CliMsg.asUser = uid.UserId()
 		}
 		pktsub := msg.CliMsg.Sub
-		msg.CliMsg.rcptTo = msg.RcptTo
-		msg.CliMsg.original = pktsub.Topic
-		msg.CliMsg.id = pktsub.Id
 		sessionJoin := &sessionJoin{
 			pkt:      msg.CliMsg,
 			sess:     sess,
@@ -590,20 +587,7 @@ func (c *Cluster) TopicMaster(msg *ClusterReq, rejected *bool) error {
 			msg.CliMsg.asUser = uid.UserId()
 		}
 		msg.CliMsg.authLvl = int(authLvl)
-		msg.CliMsg.rcptTo = msg.RcptTo
-		switch {
-		case msg.CliMsg.Get != nil:
-			msg.CliMsg.id = msg.CliMsg.Get.Id
-			msg.CliMsg.original = msg.CliMsg.Get.Topic
-		case msg.CliMsg.Set != nil:
-			msg.CliMsg.id = msg.CliMsg.Set.Id
-			msg.CliMsg.original = msg.CliMsg.Set.Topic
-		case msg.CliMsg.Del != nil:
-			msg.CliMsg.id = msg.CliMsg.Del.Id
-			msg.CliMsg.original = msg.CliMsg.Del.Topic
-		default:
-			log.Panic("cluster: topic proxy meta request must container either Get or Set field")
-		}
+
 		req := &metaReq{
 			pkt:  msg.CliMsg,
 			sess: sess,

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -110,7 +110,7 @@ type ClusterReq struct {
 
 	// Client message. Set for C2S requests.
 	CliMsg *ClientComMessage
-	// Message to be routed. Set for route requests.
+	// Message to be routed. Set for intra-cluster route requests.
 	SrvMsg *ServerComMessage
 	// Topic message.
 	// Set for topic proxy to topic master requests.
@@ -604,10 +604,9 @@ func (c *Cluster) TopicMaster(msg *ClusterReq, rejected *bool) error {
 			log.Panic("cluster: topic proxy meta request must container either Get or Set field")
 		}
 		req := &metaReq{
-			topic: msg.RcptTo,
-			pkt:   msg.CliMsg,
-			sess:  sess,
-			what:  msg.TopicMsg.MetaReq.What,
+			pkt:  msg.CliMsg,
+			sess: sess,
+			what: msg.TopicMsg.MetaReq.What,
 			// Impersonate the original session.
 			sessOverrides: &sessionOverrides{
 				sid:     origSid,
@@ -1079,7 +1078,7 @@ func (sess *Session) rpcWriteLoop() {
 			// The error is returned if the remote node is down. Which means the remote
 			// session is also disconnected.
 			if err := sess.clnode.respond(&ClusterResp{SrvMsg: msg.(*ServerComMessage), FromSID: sess.sid}); err != nil {
-				log.Println("cluster: sess.writeRPC: " + err.Error())
+				log.Println("cluster: sess.writeRPC:", err)
 				return
 			}
 		case msg := <-sess.stop:

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -112,8 +112,7 @@ type ClusterReq struct {
 	CliMsg *ClientComMessage
 	// Message to be routed. Set for intra-cluster route requests.
 	SrvMsg *ServerComMessage
-	// Topic message.
-	// Set for topic proxy to topic master requests.
+	// Topic message. Set for topic proxy to topic master requests.
 	TopicMsg *ProxyTopicMessage
 
 	// Root user may send messages on behalf of other users.
@@ -546,6 +545,7 @@ func (c *Cluster) TopicMaster(msg *ClusterReq, rejected *bool) error {
 			msg.CliMsg.asUser = uid.UserId()
 		}
 		pktsub := msg.CliMsg.Sub
+		msg.CliMsg.rcptTo = msg.RcptTo
 		msg.CliMsg.original = pktsub.Topic
 		msg.CliMsg.id = pktsub.Id
 		sessionJoin := &sessionJoin{
@@ -590,6 +590,7 @@ func (c *Cluster) TopicMaster(msg *ClusterReq, rejected *bool) error {
 			msg.CliMsg.asUser = uid.UserId()
 		}
 		msg.CliMsg.authLvl = int(authLvl)
+		msg.CliMsg.rcptTo = msg.RcptTo
 		switch {
 		case msg.CliMsg.Get != nil:
 			msg.CliMsg.id = msg.CliMsg.Get.Id

--- a/server/datamodel.go
+++ b/server/datamodel.go
@@ -597,7 +597,7 @@ type ServerComMessage struct {
 	id string
 	// Routable (expanded) name of the topic.
 	rcptto string
-	// Timestamp for consistency of timestamps in {ctrl} messages
+	// Timestamp for consistency of timestamps in {ctrl} messages.
 	timestamp time.Time
 	// User ID of the sender of the original message.
 	asUser string
@@ -605,7 +605,7 @@ type ServerComMessage struct {
 	sess *Session
 	// Session parameter overrides. Used when a topic is hosted remotely. Could be nil.
 	sessOverrides *sessionOverrides
-	// Should the packet be sent to the original session? SessionID to skip.
+	// Should the packet be sent to the original session? Session ID to skip.
 	skipSid string
 	// User id affected by this message.
 	uid types.Uid

--- a/server/datamodel.go
+++ b/server/datamodel.go
@@ -307,12 +307,14 @@ type ClientComMessage struct {
 	Del   *MsgClientDel   `json:"del"`
 	Note  *MsgClientNote  `json:"note"`
 
+	// Internal fields, routed only within the cluster.
+
 	// Message ID denormalized
-	id string
+	Id string `json:"-"`
 	// Un-routable (original) topic name denormalized from XXX.Topic.
-	original string
+	Original string `json:"-"`
 	// Routable (expanded) topic name.
-	rcptTo string
+	RcptTo string
 	// Sender's UserId as string.
 	asUser string
 	// Sender's authentication level.

--- a/server/datamodel.go
+++ b/server/datamodel.go
@@ -314,11 +314,11 @@ type ClientComMessage struct {
 	// Un-routable (original) topic name denormalized from XXX.Topic.
 	Original string `json:"-"`
 	// Routable (expanded) topic name.
-	RcptTo string
+	RcptTo string `json:"-"`
 	// Sender's UserId as string.
-	asUser string
+	AsUser string `json:"-"`
 	// Sender's authentication level.
-	authLvl int
+	AuthLvl int `json:"-"`
 	// Timestamp when this message was received by the server.
 	timestamp time.Time
 }

--- a/server/datamodel.go
+++ b/server/datamodel.go
@@ -311,13 +311,13 @@ type ClientComMessage struct {
 	id string
 	// Un-routable (original) topic name denormalized from XXX.Topic.
 	original string
-	// Routable (expanded) topic name
+	// Routable (expanded) topic name.
 	rcptTo string
-	// Sender's UserId as string
+	// Sender's UserId as string.
 	asUser string
-	// Sender's authentication level
+	// Sender's authentication level.
 	authLvl int
-	// Timestamp when this message was received by the server
+	// Timestamp when this message was received by the server.
 	timestamp time.Time
 }
 

--- a/server/hub.go
+++ b/server/hub.go
@@ -376,7 +376,7 @@ func (h *Hub) topicUnreg(sess *Session, topic string, msg *ClientComMessage, rea
 	now := time.Now().UTC().Round(time.Millisecond)
 
 	if reason == StopDeleted {
-		asUid := types.ParseUserId(msg.asUser)
+		asUid := types.ParseUserId(msg.AsUser)
 		// Case 1 (unregister and delete)
 		if t := h.topicGet(topic); t != nil {
 			// Case 1.1: topic is online
@@ -407,7 +407,7 @@ func (h *Hub) topicUnreg(sess *Session, topic string, msg *ClientComMessage, rea
 		} else {
 			// Case 1.2: topic is offline.
 
-			asUid := types.ParseUserId(msg.asUser)
+			asUid := types.ParseUserId(msg.AsUser)
 			// Get all subscribers: we need to know how many are left and notify them.
 			subs, err := store.Topics.GetSubs(topic, nil)
 			if err != nil {
@@ -553,7 +553,7 @@ func (h *Hub) stopTopicsForUser(uid types.Uid, reason int, alldone chan<- bool) 
 func replyOfflineTopicGetDesc(sess *Session, msg *ClientComMessage) {
 	now := types.TimeNow()
 	desc := &MsgTopicDesc{}
-	asUid := types.ParseUserId(msg.asUser)
+	asUid := types.ParseUserId(msg.AsUser)
 	topic := msg.RcptTo
 
 	if strings.HasPrefix(topic, "grp") {
@@ -571,7 +571,7 @@ func replyOfflineTopicGetDesc(sess *Session, msg *ClientComMessage) {
 		desc.CreatedAt = &stopic.CreatedAt
 		desc.UpdatedAt = &stopic.UpdatedAt
 		desc.Public = stopic.Public
-		if stopic.Owner == msg.asUser {
+		if stopic.Owner == msg.AsUser {
 			desc.DefaultAcs = &MsgDefaultAcsMode{
 				Auth: stopic.Access.Auth.String(),
 				Anon: stopic.Access.Anon.String()}
@@ -643,12 +643,12 @@ func replyOfflineTopicGetDesc(sess *Session, msg *ClientComMessage) {
 func replyOfflineTopicGetSub(sess *Session, msg *ClientComMessage) {
 	now := types.TimeNow()
 
-	if msg.Get.Sub != nil && msg.Get.Sub.User != "" && msg.Get.Sub.User != msg.asUser {
+	if msg.Get.Sub != nil && msg.Get.Sub.User != "" && msg.Get.Sub.User != msg.AsUser {
 		sess.queueOut(ErrPermissionDenied(msg.Id, msg.Original, now))
 		return
 	}
 
-	ssub, err := store.Subs.Get(msg.RcptTo, types.ParseUserId(msg.asUser))
+	ssub, err := store.Subs.Get(msg.RcptTo, types.ParseUserId(msg.AsUser))
 	if err != nil {
 		log.Println("replyOfflineTopicGetSub:", err)
 		sess.queueOut(decodeStoreError(err, msg.Id, msg.Original, now, nil))
@@ -695,12 +695,12 @@ func replyOfflineTopicSetSub(sess *Session, msg *ClientComMessage) {
 		return
 	}
 
-	if msg.Set.Sub != nil && msg.Set.Sub.User != "" && msg.Set.Sub.User != msg.asUser {
+	if msg.Set.Sub != nil && msg.Set.Sub.User != "" && msg.Set.Sub.User != msg.AsUser {
 		sess.queueOut(ErrPermissionDenied(msg.Id, msg.Original, now))
 		return
 	}
 
-	asUid := types.ParseUserId(msg.asUser)
+	asUid := types.ParseUserId(msg.AsUser)
 
 	sub, err := store.Subs.Get(msg.RcptTo, asUid)
 	if err != nil {

--- a/server/hub.go
+++ b/server/hub.go
@@ -151,7 +151,7 @@ func newHub() *Hub {
 
 	if !globals.cluster.isRemoteTopic("sys") {
 		// Initialize system 'sys' topic. There is only one sys topic per cluster.
-		h.join <- &sessionJoin{internal: true, pkt: &ClientComMessage{rcptTo: "sys", original: "sys"}}
+		h.join <- &sessionJoin{internal: true, pkt: &ClientComMessage{RcptTo: "sys", Original: "sys"}}
 	}
 
 	return h
@@ -173,13 +173,13 @@ func (h *Hub) run() {
 			// 3. Attach session to the topic
 
 			// Is the topic already loaded?
-			t := h.topicGet(sreg.pkt.rcptTo)
+			t := h.topicGet(sreg.pkt.RcptTo)
 			if t == nil {
 				// Topic does not exist or not loaded.
-				t = &Topic{name: sreg.pkt.rcptTo,
-					xoriginal: sreg.pkt.original,
+				t = &Topic{name: sreg.pkt.RcptTo,
+					xoriginal: sreg.pkt.Original,
 					// Indicates a proxy topic.
-					isProxy:   globals.cluster.isRemoteTopic(sreg.pkt.rcptTo),
+					isProxy:   globals.cluster.isRemoteTopic(sreg.pkt.RcptTo),
 					sessions:  make(map[*Session]perSessionData),
 					broadcast: make(chan *ServerComMessage, 256),
 					reg:       make(chan *sessionJoin, 32),
@@ -202,7 +202,7 @@ func (h *Hub) run() {
 				// Topic is created in suspended state because it's not yet configured.
 				t.markPaused(true)
 				// Save topic now to prevent race condition.
-				h.topicPut(sreg.pkt.rcptTo, t)
+				h.topicPut(sreg.pkt.RcptTo, t)
 
 				// Configure the topic.
 				go topicInit(t, sreg, h)
@@ -295,7 +295,7 @@ func (h *Hub) run() {
 				// Yes, 'sys' has migrated here. Initialize it.
 				// The h.join is unbuffered. We must call from another goroutine. Otherwise deadlock.
 				go func() {
-					h.join <- &sessionJoin{internal: true, pkt: &ClientComMessage{rcptTo: "sys", original: "sys"}}
+					h.join <- &sessionJoin{internal: true, pkt: &ClientComMessage{RcptTo: "sys", Original: "sys"}}
 				}()
 			}
 
@@ -386,11 +386,11 @@ func (h *Hub) topicUnreg(sess *Session, topic string, msg *ClientComMessage, rea
 				t.markPaused(true)
 				if err := store.Topics.Delete(topic, msg.Del.Hard); err != nil {
 					t.markPaused(false)
-					sess.queueOut(ErrUnknown(msg.id, msg.original, now))
+					sess.queueOut(ErrUnknown(msg.Id, msg.Original, now))
 					return err
 				}
 
-				sess.queueOut(NoErr(msg.id, msg.original, now))
+				sess.queueOut(NoErr(msg.Id, msg.Original, now))
 
 				h.topicDel(topic)
 				t.markDeleted()
@@ -411,12 +411,12 @@ func (h *Hub) topicUnreg(sess *Session, topic string, msg *ClientComMessage, rea
 			// Get all subscribers: we need to know how many are left and notify them.
 			subs, err := store.Topics.GetSubs(topic, nil)
 			if err != nil {
-				sess.queueOut(ErrUnknown(msg.id, msg.original, now))
+				sess.queueOut(ErrUnknown(msg.Id, msg.Original, now))
 				return err
 			}
 
 			if len(subs) == 0 {
-				sess.queueOut(InfoNoAction(msg.id, msg.original, now))
+				sess.queueOut(InfoNoAction(msg.Id, msg.Original, now))
 				return nil
 			}
 
@@ -431,7 +431,7 @@ func (h *Hub) topicUnreg(sess *Session, topic string, msg *ClientComMessage, rea
 
 			if sub == nil {
 				// If user has no subscription, tell him all is fine
-				sess.queueOut(InfoNoAction(msg.id, msg.original, now))
+				sess.queueOut(InfoNoAction(msg.Id, msg.Original, now))
 				return nil
 			}
 
@@ -442,7 +442,7 @@ func (h *Hub) topicUnreg(sess *Session, topic string, msg *ClientComMessage, rea
 				if tcat == types.TopicCatP2P && len(subs) < 2 {
 					// This is a P2P topic and fewer than 2 subscriptions, delete the entire topic
 					if err := store.Topics.Delete(topic, msg.Del.Hard); err != nil {
-						sess.queueOut(ErrUnknown(msg.id, msg.original, now))
+						sess.queueOut(ErrUnknown(msg.Id, msg.Original, now))
 						return err
 					}
 
@@ -450,19 +450,19 @@ func (h *Hub) topicUnreg(sess *Session, topic string, msg *ClientComMessage, rea
 					// Not P2P or more than 1 subscription left.
 					// Delete user's own subscription only
 					if err == types.ErrNotFound {
-						sess.queueOut(InfoNoAction(msg.id, msg.original, now))
+						sess.queueOut(InfoNoAction(msg.Id, msg.Original, now))
 						err = nil
 					} else {
-						sess.queueOut(ErrUnknown(msg.id, msg.original, now))
+						sess.queueOut(ErrUnknown(msg.Id, msg.Original, now))
 					}
 					return err
 				}
 
 				// Notify user's other sessions that the subscription is gone
-				presSingleUserOfflineOffline(asUid, msg.original, "gone", nilPresParams, sess.sid)
+				presSingleUserOfflineOffline(asUid, msg.Original, "gone", nilPresParams, sess.sid)
 				if tcat == types.TopicCatP2P && len(subs) == 2 {
 					uname1 := asUid.UserId()
-					uid2 := types.ParseUserId(msg.original)
+					uid2 := types.ParseUserId(msg.Original)
 					// Tell user1 to stop sending updates to user2 without passing change to user1's sessions.
 					presSingleUserOfflineOffline(asUid, uid2.UserId(), "?none+rem", nilPresParams, "")
 					// Don't change the online status of user1, just ask user2 to stop notification exchange.
@@ -474,15 +474,15 @@ func (h *Hub) topicUnreg(sess *Session, topic string, msg *ClientComMessage, rea
 				// Case 1.2.1.1: owner, delete the group topic from db.
 				// Only group topics have owners.
 				if err := store.Topics.Delete(topic, msg.Del.Hard); err != nil {
-					sess.queueOut(ErrUnknown(msg.id, msg.original, now))
+					sess.queueOut(ErrUnknown(msg.Id, msg.Original, now))
 					return err
 				}
 
 				// Notify subscribers that the group topic is gone.
-				presSubsOfflineOffline(msg.original, tcat, subs, "gone", &presParams{}, sess.sid)
+				presSubsOfflineOffline(msg.Original, tcat, subs, "gone", &presParams{}, sess.sid)
 			}
 
-			sess.queueOut(NoErr(msg.id, msg.original, now))
+			sess.queueOut(NoErr(msg.Id, msg.Original, now))
 		}
 
 	} else {
@@ -499,7 +499,7 @@ func (h *Hub) topicUnreg(sess *Session, topic string, msg *ClientComMessage, rea
 
 		// sess && msg could be nil if the topic is being killed by timer or due to rehashing.
 		if sess != nil && msg != nil {
-			sess.queueOut(NoErr(msg.id, msg.original, now))
+			sess.queueOut(NoErr(msg.Id, msg.Original, now))
 		}
 	}
 
@@ -553,18 +553,18 @@ func (h *Hub) stopTopicsForUser(uid types.Uid, reason int, alldone chan<- bool) 
 func replyOfflineTopicGetDesc(sess *Session, msg *ClientComMessage) {
 	now := types.TimeNow()
 	desc := &MsgTopicDesc{}
-	topic := msg.rcptTo
 	asUid := types.ParseUserId(msg.asUser)
+	topic := msg.RcptTo
 
 	if strings.HasPrefix(topic, "grp") {
 		stopic, err := store.Topics.Get(topic)
 		if err != nil {
 			log.Println("replyOfflineTopicGetDesc", err)
-			sess.queueOut(decodeStoreError(err, msg.id, msg.original, now, nil))
+			sess.queueOut(decodeStoreError(err, msg.Id, msg.Original, now, nil))
 			return
 		}
 		if stopic == nil {
-			sess.queueOut(ErrTopicNotFound(msg.id, msg.original, now))
+			sess.queueOut(ErrTopicNotFound(msg.Id, msg.Original, now))
 			return
 		}
 
@@ -596,17 +596,17 @@ func replyOfflineTopicGetDesc(sess *Session, msg *ClientComMessage) {
 
 		if uid.IsZero() {
 			log.Println("replyOfflineTopicGetDesc: malformed p2p topic name")
-			sess.queueOut(ErrMalformed(msg.id, msg.original, now))
+			sess.queueOut(ErrMalformed(msg.Id, msg.Original, now))
 			return
 		}
 
 		suser, err := store.Users.Get(uid)
 		if err != nil {
-			sess.queueOut(decodeStoreError(err, msg.id, msg.original, now, nil))
+			sess.queueOut(decodeStoreError(err, msg.Id, msg.Original, now, nil))
 			return
 		}
 		if suser == nil {
-			sess.queueOut(ErrUserNotFound(msg.id, msg.original, now))
+			sess.queueOut(ErrUserNotFound(msg.Id, msg.Original, now))
 			return
 		}
 		desc.CreatedAt = &suser.CreatedAt
@@ -620,7 +620,7 @@ func replyOfflineTopicGetDesc(sess *Session, msg *ClientComMessage) {
 	sub, err := store.Subs.Get(topic, asUid)
 	if err != nil {
 		log.Println("replyOfflineTopicGetDesc:", err)
-		sess.queueOut(decodeStoreError(err, msg.id, msg.original, now, nil))
+		sess.queueOut(decodeStoreError(err, msg.Id, msg.Original, now, nil))
 		return
 	}
 
@@ -634,7 +634,7 @@ func replyOfflineTopicGetDesc(sess *Session, msg *ClientComMessage) {
 	}
 
 	sess.queueOut(&ServerComMessage{
-		Meta: &MsgServerMeta{Id: msg.id, Topic: msg.original, Timestamp: &now, Desc: desc}})
+		Meta: &MsgServerMeta{Id: msg.Id, Topic: msg.Original, Timestamp: &now, Desc: desc}})
 }
 
 // replyOfflineTopicGetSub reads user's subscription from the database.
@@ -642,22 +642,21 @@ func replyOfflineTopicGetDesc(sess *Session, msg *ClientComMessage) {
 // The requester must be subscribed but need not be attached.
 func replyOfflineTopicGetSub(sess *Session, msg *ClientComMessage) {
 	now := types.TimeNow()
-	topic := msg.rcptTo
 
 	if msg.Get.Sub != nil && msg.Get.Sub.User != "" && msg.Get.Sub.User != msg.asUser {
-		sess.queueOut(ErrPermissionDenied(msg.id, msg.original, now))
+		sess.queueOut(ErrPermissionDenied(msg.Id, msg.Original, now))
 		return
 	}
 
-	ssub, err := store.Subs.Get(topic, types.ParseUserId(msg.asUser))
+	ssub, err := store.Subs.Get(msg.RcptTo, types.ParseUserId(msg.asUser))
 	if err != nil {
 		log.Println("replyOfflineTopicGetSub:", err)
-		sess.queueOut(decodeStoreError(err, msg.id, msg.original, now, nil))
+		sess.queueOut(decodeStoreError(err, msg.Id, msg.Original, now, nil))
 		return
 	}
 
 	if ssub == nil {
-		sess.queueOut(ErrNotFound(msg.id, msg.original, now))
+		sess.queueOut(ErrNotFound(msg.Id, msg.Original, now))
 		return
 	}
 
@@ -669,7 +668,7 @@ func replyOfflineTopicGetSub(sess *Session, msg *ClientComMessage) {
 			Given: ssub.ModeGiven.String(),
 			Mode:  (ssub.ModeGiven & ssub.ModeWant).String()}
 		// Fnd is asymmetric: desc.private is a string, but sub.private is a []string.
-		if types.GetTopicCat(topic) != types.TopicCatFnd {
+		if types.GetTopicCat(msg.RcptTo) != types.TopicCatFnd {
 			sub.Private = ssub.Private
 		}
 		sub.User = types.ParseUid(ssub.User).UserId()
@@ -682,7 +681,7 @@ func replyOfflineTopicGetSub(sess *Session, msg *ClientComMessage) {
 	}
 
 	sess.queueOut(&ServerComMessage{
-		Meta: &MsgServerMeta{Id: msg.id, Topic: msg.original, Timestamp: &now, Sub: []MsgTopicSub{sub}}})
+		Meta: &MsgServerMeta{Id: msg.Id, Topic: msg.Original, Timestamp: &now, Sub: []MsgTopicSub{sub}}})
 }
 
 // replyOfflineTopicSetSub updates Desc.Private and Sub.Mode when the topic is not loaded in memory.
@@ -690,29 +689,28 @@ func replyOfflineTopicGetSub(sess *Session, msg *ClientComMessage) {
 // topic but does not need to be attached.
 func replyOfflineTopicSetSub(sess *Session, msg *ClientComMessage) {
 	now := types.TimeNow()
-	topic := msg.rcptTo
 
 	if (msg.Set.Desc == nil || msg.Set.Desc.Private == nil) && (msg.Set.Sub == nil || msg.Set.Sub.Mode == "") {
-		sess.queueOut(InfoNotModified(msg.id, msg.original, now))
+		sess.queueOut(InfoNotModified(msg.Id, msg.Original, now))
 		return
 	}
 
 	if msg.Set.Sub != nil && msg.Set.Sub.User != "" && msg.Set.Sub.User != msg.asUser {
-		sess.queueOut(ErrPermissionDenied(msg.id, msg.original, now))
+		sess.queueOut(ErrPermissionDenied(msg.Id, msg.Original, now))
 		return
 	}
 
 	asUid := types.ParseUserId(msg.asUser)
 
-	sub, err := store.Subs.Get(topic, asUid)
+	sub, err := store.Subs.Get(msg.RcptTo, asUid)
 	if err != nil {
 		log.Println("replyOfflineTopicSetSub get sub:", err)
-		sess.queueOut(decodeStoreError(err, msg.id, msg.original, now, nil))
+		sess.queueOut(decodeStoreError(err, msg.Id, msg.Original, now, nil))
 		return
 	}
 
 	if sub == nil || sub.DeletedAt != nil {
-		sess.queueOut(ErrNotFound(msg.id, msg.original, now))
+		sess.queueOut(ErrNotFound(msg.Id, msg.Original, now))
 		return
 	}
 
@@ -730,17 +728,17 @@ func replyOfflineTopicSetSub(sess *Session, msg *ClientComMessage) {
 		var modeWant types.AccessMode
 		if err = modeWant.UnmarshalText([]byte(msg.Set.Sub.Mode)); err != nil {
 			log.Println("replyOfflineTopicSetSub mode:", err)
-			sess.queueOut(decodeStoreError(err, msg.id, msg.original, now, nil))
+			sess.queueOut(decodeStoreError(err, msg.Id, msg.Original, now, nil))
 			return
 		}
 
 		if modeWant.IsOwner() != sub.ModeWant.IsOwner() {
 			// No ownership changes here.
-			sess.queueOut(ErrPermissionDenied(msg.id, msg.original, now))
+			sess.queueOut(ErrPermissionDenied(msg.Id, msg.Original, now))
 			return
 		}
 
-		if types.GetTopicCat(topic) == types.TopicCatP2P {
+		if types.GetTopicCat(msg.RcptTo) == types.TopicCatP2P {
 			// For P2P topics ignore requests exceeding types.ModeCP2P and do not allow
 			// removal of 'A' permission.
 			modeWant = modeWant&types.ModeCP2P | types.ModeApprove
@@ -754,10 +752,10 @@ func replyOfflineTopicSetSub(sess *Session, msg *ClientComMessage) {
 	}
 
 	if len(update) > 0 {
-		err = store.Subs.Update(topic, asUid, update, true)
+		err = store.Subs.Update(msg.RcptTo, asUid, update, true)
 		if err != nil {
 			log.Println("replyOfflineTopicSetSub update:", err)
-			sess.queueOut(decodeStoreError(err, msg.id, msg.original, now, nil))
+			sess.queueOut(decodeStoreError(err, msg.Id, msg.Original, now, nil))
 		} else {
 			var params interface{}
 			if update["ModeWant"] != nil {
@@ -766,9 +764,9 @@ func replyOfflineTopicSetSub(sess *Session, msg *ClientComMessage) {
 					Want:  sub.ModeWant.String(),
 					Mode:  (sub.ModeGiven & sub.ModeWant).String()}}
 			}
-			sess.queueOut(NoErrParams(msg.id, msg.original, now, params))
+			sess.queueOut(NoErrParams(msg.Id, msg.Original, now, params))
 		}
 	} else {
-		sess.queueOut(InfoNotModified(msg.id, msg.original, now))
+		sess.queueOut(InfoNotModified(msg.Id, msg.Original, now))
 	}
 }

--- a/server/init_topic.go
+++ b/server/init_topic.go
@@ -51,7 +51,7 @@ func topicInit(t *Topic, sreg *sessionJoin, h *Hub) {
 		// Remove topic from cache to prevent hub from forwarding more messages to it.
 		h.topicDel(sreg.pkt.rcptTo)
 
-		log.Println("hub: failed to load or create topic:", sreg.pkt.rcptTo, err)
+		log.Println("int_topic: failed to load or create topic:", sreg.pkt.rcptTo, err)
 		sreg.sess.queueOutWithOverrides(decodeStoreError(err, sreg.pkt.id, t.xoriginal, timestamp, nil), sreg.sessOverrides)
 
 		// Re-queue pending requests to join the topic.

--- a/server/init_topic.go
+++ b/server/init_topic.go
@@ -51,7 +51,7 @@ func topicInit(t *Topic, sreg *sessionJoin, h *Hub) {
 		// Remove topic from cache to prevent hub from forwarding more messages to it.
 		h.topicDel(sreg.pkt.rcptTo)
 
-		log.Println("int_topic: failed to load or create topic:", sreg.pkt.rcptTo, err)
+		log.Println("init_topic: failed to load or create topic:", sreg.pkt.rcptTo, err)
 		sreg.sess.queueOutWithOverrides(decodeStoreError(err, sreg.pkt.id, t.xoriginal, timestamp, nil), sreg.sessOverrides)
 
 		// Re-queue pending requests to join the topic.

--- a/server/init_topic.go
+++ b/server/init_topic.go
@@ -49,10 +49,10 @@ func topicInit(t *Topic, sreg *sessionJoin, h *Hub) {
 	// Failed to create or load the topic.
 	if err != nil {
 		// Remove topic from cache to prevent hub from forwarding more messages to it.
-		h.topicDel(sreg.pkt.rcptTo)
+		h.topicDel(sreg.pkt.RcptTo)
 
-		log.Println("init_topic: failed to load or create topic:", sreg.pkt.rcptTo, err)
-		sreg.sess.queueOutWithOverrides(decodeStoreError(err, sreg.pkt.id, t.xoriginal, timestamp, nil), sreg.sessOverrides)
+		log.Println("init_topic: failed to load or create topic:", sreg.pkt.RcptTo, err)
+		sreg.sess.queueOutWithOverrides(decodeStoreError(err, sreg.pkt.Id, t.xoriginal, timestamp, nil), sreg.sessOverrides)
 
 		// Re-queue pending requests to join the topic.
 		for len(t.reg) > 0 {
@@ -71,7 +71,7 @@ func topicInit(t *Topic, sreg *sessionJoin, h *Hub) {
 		}
 		for len(t.meta) > 0 {
 			msg := <-t.meta
-			msg.sess.queueOutWithOverrides(ErrLocked(msg.pkt.id, t.xoriginal, timestamp), sreg.sessOverrides)
+			msg.sess.queueOutWithOverrides(ErrLocked(msg.pkt.Id, t.xoriginal, timestamp), sreg.sessOverrides)
 		}
 		if len(t.exit) > 0 {
 			msg := <-t.exit
@@ -85,7 +85,7 @@ func topicInit(t *Topic, sreg *sessionJoin, h *Hub) {
 
 	// prevent newly initialized topics to go live while shutdown in progress
 	if globals.shuttingDown {
-		h.topicDel(sreg.pkt.rcptTo)
+		h.topicDel(sreg.pkt.RcptTo)
 		return
 	}
 
@@ -547,7 +547,7 @@ func initTopicNewGrp(t *Topic, sreg *sessionJoin) error {
 	// t.lastId & t.delId are not set for new topics
 
 	stopic := &types.Topic{
-		ObjHeader: types.ObjHeader{Id: sreg.pkt.rcptTo, CreatedAt: timestamp},
+		ObjHeader: types.ObjHeader{Id: sreg.pkt.RcptTo, CreatedAt: timestamp},
 		Access:    types.DefaultAccess{Auth: t.accessAuth, Anon: t.accessAnon},
 		Tags:      tags,
 		Public:    t.public}

--- a/server/init_topic.go
+++ b/server/init_topic.go
@@ -161,7 +161,7 @@ func initTopicMe(t *Topic, sreg *sessionJoin) error {
 func initTopicFnd(t *Topic, sreg *sessionJoin) error {
 	t.cat = types.TopicCatFnd
 
-	uid := types.ParseUserId(sreg.pkt.asUser)
+	uid := types.ParseUserId(sreg.pkt.AsUser)
 	if uid.IsZero() {
 		return types.ErrNotFound
 	}
@@ -275,7 +275,7 @@ func initTopicP2P(t *Topic, sreg *sessionJoin) error {
 
 		// Fetching records for both users.
 		// Requester.
-		userID1 := types.ParseUserId(sreg.pkt.asUser)
+		userID1 := types.ParseUserId(sreg.pkt.AsUser)
 		// The other user.
 		userID2 := types.ParseUserId(t.xoriginal)
 		// User index: u1 - requester, u2 - responder, the other user
@@ -347,7 +347,7 @@ func initTopicP2P(t *Topic, sreg *sessionJoin) error {
 		if sub1 == nil {
 
 			// Set user1's ModeGiven from user2's default values
-			userData.modeGiven = selectAccessMode(auth.Level(sreg.pkt.authLvl),
+			userData.modeGiven = selectAccessMode(auth.Level(sreg.pkt.AuthLvl),
 				users[u2].Access.Anon,
 				users[u2].Access.Auth,
 				types.ModeCP2P)
@@ -402,7 +402,7 @@ func initTopicP2P(t *Topic, sreg *sessionJoin) error {
 
 		if !user1only {
 			// sub2 is being created, assign sub2.modeWant to what user2 gave to user1 (sub1.modeGiven)
-			sub2.ModeWant = selectAccessMode(auth.Level(sreg.pkt.authLvl),
+			sub2.ModeWant = selectAccessMode(auth.Level(sreg.pkt.AuthLvl),
 				users[u2].Access.Anon,
 				users[u2].Access.Auth,
 				types.ModeCP2P)
@@ -472,7 +472,7 @@ func initTopicNewGrp(t *Topic, sreg *sessionJoin) error {
 	t.cat = types.TopicCatGrp
 
 	// Generic topics have parameters stored in the topic object
-	t.owner = types.ParseUserId(sreg.pkt.asUser)
+	t.owner = types.ParseUserId(sreg.pkt.AsUser)
 
 	t.accessAuth = getDefaultAccess(t.cat, true)
 	t.accessAnon = getDefaultAccess(t.cat, false)

--- a/server/pbconverter.go
+++ b/server/pbconverter.go
@@ -302,8 +302,8 @@ func pbCliSerialize(msg *ClientComMessage) *pbx.ClientMsg {
 		return nil
 	}
 
-	pkt.OnBehalfOf = msg.asUser
-	pkt.AuthLevel = pbx.AuthLevel(msg.authLvl)
+	pkt.OnBehalfOf = msg.AsUser
+	pkt.AuthLevel = pbx.AuthLevel(msg.AuthLvl)
 
 	return &pkt
 }
@@ -409,8 +409,8 @@ func pbCliDeserialize(pkt *pbx.ClientMsg) *ClientComMessage {
 		}
 	}
 
-	msg.asUser = pkt.GetOnBehalfOf()
-	msg.authLvl = int(pkt.GetAuthLevel())
+	msg.AsUser = pkt.GetOnBehalfOf()
+	msg.AuthLvl = int(pkt.GetAuthLevel())
 
 	return &msg
 }

--- a/server/run-cluster.sh
+++ b/server/run-cluster.sh
@@ -5,14 +5,16 @@
 # Names of cluster nodes
 ALL_NODE_NAMES=( one two three )
 # Port where the first node will listen for client connections over http
-HTTP_BASE_PORT=6080
+HTTP_BASE_PORT=6060
 # Port where the first node will listen for gRPC intra-cluster connections.
 GRPC_BASE_PORT=16060
 
-# Assign command line parameters to variables.
-# for line in $@; do
-#  eval "$line"
-#done
+USAGE="Usage: $0 [ --config <path_to_tinode.conf> ] {start|stop}"
+
+if [ "$#" -lt "1" ]; then
+  echo $USAGE
+  exit 1
+fi
 
 while [[ $# -gt 0 ]]; do
   key="$1"
@@ -30,7 +32,7 @@ while [[ $# -gt 0 ]]; do
         TINODE_CONF="tinode.conf"
       fi
 
-      echo "HTTP ports 6080-6082, gRPC ports 16060-16062, config ${config}"
+      echo "HTTP ports 6060-6062, gRPC ports 16060-16062, config ${config}"
 
       HTTP_PORT=$HTTP_BASE_PORT
       GRPC_PORT=$GRPC_BASE_PORT
@@ -60,7 +62,7 @@ while [[ $# -gt 0 ]]; do
       exit 0
       ;;
     *)
-      echo $"Usage: $0 {start|stop} [ --config <path_to_tinode.conf> ]"
+      echo $USAGE
       exit 1
   esac
 done

--- a/server/session.go
+++ b/server/session.go
@@ -446,11 +446,11 @@ func (s *Session) leave(msg *ClientComMessage) {
 			// Unlink from topic, topic will send a reply.
 			s.delSub(msg.rcptTo)
 			sub.done <- &sessionLeave{
-				userId: types.ParseUserId(msg.asUser),
-				topic:  msg.original,
-				sess:   s,
-				unsub:  msg.Leave.Unsub,
-				id:     msg.id}
+				userId:   types.ParseUserId(msg.asUser),
+				original: msg.original,
+				sess:     s,
+				unsub:    msg.Leave.Unsub,
+				id:       msg.id}
 		}
 	} else if !msg.Leave.Unsub {
 		// Session is not attached to the topic, wants to leave - fine, no change
@@ -819,10 +819,9 @@ func (s *Session) get(msg *ClientComMessage) {
 
 	sub := s.getSub(msg.rcptTo)
 	meta := &metaReq{
-		topic: msg.rcptTo,
-		pkt:   msg,
-		sess:  s,
-		what:  parseMsgClientMeta(msg.Get.What)}
+		pkt:  msg,
+		sess: s,
+		what: parseMsgClientMeta(msg.Get.What)}
 
 	if meta.what == 0 {
 		s.queueOut(ErrMalformed(msg.id, msg.original, msg.timestamp))
@@ -848,9 +847,8 @@ func (s *Session) set(msg *ClientComMessage) {
 	}
 
 	meta := &metaReq{
-		topic: msg.rcptTo,
-		pkt:   msg,
-		sess:  s}
+		pkt:  msg,
+		sess: s}
 
 	if msg.Set.Desc != nil {
 		meta.what = constMsgMetaDesc
@@ -907,10 +905,9 @@ func (s *Session) del(msg *ClientComMessage) {
 	if sub != nil && what != constMsgDelTopic {
 		// Session is attached, deleting subscription or messages. Send to topic.
 		sub.meta <- &metaReq{
-			topic: msg.rcptTo,
-			pkt:   msg,
-			sess:  s,
-			what:  what}
+			pkt:  msg,
+			sess: s,
+			what: what}
 
 	} else if what == constMsgDelTopic {
 		// Deleting topic: for sessions attached or not attached, send request to hub first.

--- a/server/topic.go
+++ b/server/topic.go
@@ -397,7 +397,7 @@ func (t *Topic) runProxy(hub *Hub) {
 
 		case <-killTimer.C:
 			// Topic timeout
-			hub.unreg <- &topicUnreg{topic: t.name}
+			hub.unreg <- &topicUnreg{rcptTo: t.name}
 
 		case <-defrNotifTimer.C:
 			t.onDeferredNotificationTimer()
@@ -996,7 +996,7 @@ func (t *Topic) runLocal(hub *Hub) {
 
 		case <-killTimer.C:
 			// Topic timeout
-			hub.unreg <- &topicUnreg{topic: t.name}
+			hub.unreg <- &topicUnreg{rcptTo: t.name}
 			defrNotifTimer.Stop()
 			if t.cat == types.TopicCatMe {
 				uaTimer.Stop()

--- a/server/topic.go
+++ b/server/topic.go
@@ -216,7 +216,7 @@ func (t *Topic) runProxy(hub *Hub) {
 			// Request to add a connection to this topic
 			if t.isInactive() {
 				asUid := types.ParseUserId(sreg.pkt.asUser)
-				sreg.sess.queueOut(ErrLocked(sreg.pkt.id, t.original(asUid), types.TimeNow()))
+				sreg.sess.queueOut(ErrLocked(sreg.pkt.Id, t.original(asUid), types.TimeNow()))
 			} else {
 				msg := &ProxyTopicMessage{
 					JoinReq: &ProxyJoin{
@@ -560,7 +560,7 @@ func (t *Topic) runLocal(hub *Hub) {
 			if t.isInactive() {
 				asUid := types.ParseUserId(sreg.pkt.asUser)
 				sreg.sess.queueOutWithOverrides(
-					ErrLocked(sreg.pkt.id, t.original(asUid), types.TimeNow()), sreg.sessOverrides)
+					ErrLocked(sreg.pkt.Id, t.original(asUid), types.TimeNow()), sreg.sessOverrides)
 			} else {
 				// The topic is alive, so stop the kill timer, if it's ticking. We don't want the topic to die
 				// while processing the call
@@ -1160,42 +1160,42 @@ func (t *Topic) handleSubscription(h *Hub, sreg *sessionJoin) error {
 
 	if getWhat&constMsgMetaDesc != 0 {
 		// Send get.desc as a {meta} packet.
-		if err := t.replyGetDesc(sreg.sess, asUid, sreg.pkt.id, msgsub.Get.Desc, sreg.sessOverrides); err != nil {
+		if err := t.replyGetDesc(sreg.sess, asUid, sreg.pkt.Id, msgsub.Get.Desc, sreg.sessOverrides); err != nil {
 			log.Printf("topic[%s] handleSubscription Get.Desc failed: %v sid=%s", t.name, err, sreg.sess.sid)
 		}
 	}
 
 	if getWhat&constMsgMetaSub != 0 {
 		// Send get.sub response as a separate {meta} packet
-		if err := t.replyGetSub(sreg.sess, asUid, authLevel, sreg.pkt.id, msgsub.Get.Sub, sreg.sessOverrides); err != nil {
+		if err := t.replyGetSub(sreg.sess, asUid, authLevel, sreg.pkt.Id, msgsub.Get.Sub, sreg.sessOverrides); err != nil {
 			log.Printf("topic[%s] handleSubscription Get.Sub failed: %v sid=%s", t.name, err, sreg.sess.sid)
 		}
 	}
 
 	if getWhat&constMsgMetaTags != 0 {
 		// Send get.tags response as a separate {meta} packet
-		if err := t.replyGetTags(sreg.sess, asUid, sreg.pkt.id, sreg.sessOverrides); err != nil {
+		if err := t.replyGetTags(sreg.sess, asUid, sreg.pkt.Id, sreg.sessOverrides); err != nil {
 			log.Printf("topic[%s] handleSubscription Get.Tags failed: %v sid=%s", t.name, err, sreg.sess.sid)
 		}
 	}
 
 	if getWhat&constMsgMetaCred != 0 {
 		// Send get.tags response as a separate {meta} packet
-		if err := t.replyGetCreds(sreg.sess, asUid, sreg.pkt.id, sreg.sessOverrides); err != nil {
+		if err := t.replyGetCreds(sreg.sess, asUid, sreg.pkt.Id, sreg.sessOverrides); err != nil {
 			log.Printf("topic[%s] handleSubscription Get.Cred failed: %v sid=%s", t.name, err, sreg.sess.sid)
 		}
 	}
 
 	if getWhat&constMsgMetaData != 0 {
 		// Send get.data response as {data} packets
-		if err := t.replyGetData(sreg.sess, asUid, sreg.pkt.id, msgsub.Get.Data, sreg.sessOverrides); err != nil {
+		if err := t.replyGetData(sreg.sess, asUid, sreg.pkt.Id, msgsub.Get.Data, sreg.sessOverrides); err != nil {
 			log.Printf("topic[%s] handleSubscription Get.Data failed: %v sid=%s", t.name, err, sreg.sess.sid)
 		}
 	}
 
 	if getWhat&constMsgMetaDel != 0 {
 		// Send get.del response as a separate {meta} packet
-		if err := t.replyGetDel(sreg.sess, asUid, sreg.pkt.id, msgsub.Get.Del, sreg.sessOverrides); err != nil {
+		if err := t.replyGetDel(sreg.sess, asUid, sreg.pkt.Id, msgsub.Get.Del, sreg.sessOverrides); err != nil {
 			log.Printf("topic[%s] handleSubscription Get.Del failed: %v sid=%s", t.name, err, sreg.sess.sid)
 		}
 	}
@@ -1325,7 +1325,7 @@ func (t *Topic) subCommonReply(h *Hub, sreg *sessionJoin) error {
 	if msgsub.Set != nil {
 		if msgsub.Set.Sub != nil {
 			if msgsub.Set.Sub.User != "" {
-				sreg.sess.queueOutWithOverrides(ErrMalformed(sreg.pkt.id, toriginal, now), sreg.sessOverrides)
+				sreg.sess.queueOutWithOverrides(ErrMalformed(sreg.pkt.Id, toriginal, now), sreg.sessOverrides)
 				return errors.New("user id must not be specified")
 			}
 
@@ -1341,7 +1341,7 @@ func (t *Topic) subCommonReply(h *Hub, sreg *sessionJoin) error {
 	var changed bool
 	// Create new subscription or modify an existing one.
 	if changed, err = t.thisUserSub(
-		h, sreg.sess, asUid, asLvl, sreg.pkt.id, mode, private, msgsub.Background, sreg.sessOverrides); err != nil {
+		h, sreg.sess, asUid, asLvl, sreg.pkt.Id, mode, private, msgsub.Background, sreg.sessOverrides); err != nil {
 		return err
 	}
 
@@ -1358,8 +1358,8 @@ func (t *Topic) subCommonReply(h *Hub, sreg *sessionJoin) error {
 
 	// When a group topic is created, it's given a temporary name by the client.
 	// Then this name changes. Report back the original name here.
-	if sreg.created && sreg.pkt.original != toriginal {
-		params["tmpname"] = sreg.pkt.original
+	if sreg.created && sreg.pkt.Original != toriginal {
+		params["tmpname"] = sreg.pkt.Original
 	}
 
 	if len(params) == 0 {
@@ -1368,7 +1368,7 @@ func (t *Topic) subCommonReply(h *Hub, sreg *sessionJoin) error {
 	}
 
 	sreg.sess.queueOutWithOverrides(
-		NoErrParams(sreg.pkt.id, toriginal, now, params), sreg.sessOverrides)
+		NoErrParams(sreg.pkt.Id, toriginal, now, params), sreg.sessOverrides)
 
 	return nil
 }
@@ -2354,7 +2354,7 @@ func (t *Topic) replySetSub(h *Hub, sess *Session, pkt *ClientComMessage, sessOv
 	var target types.Uid
 	if target = types.ParseUserId(set.Sub.User); target.IsZero() && set.Sub.User != "" {
 		// Invalid user ID
-		sess.queueOutWithOverrides(ErrMalformed(pkt.id, toriginal, now), sessOverrides)
+		sess.queueOutWithOverrides(ErrMalformed(pkt.Id, toriginal, now), sessOverrides)
 		return errors.New("invalid user id")
 	}
 
@@ -2367,7 +2367,7 @@ func (t *Topic) replySetSub(h *Hub, sess *Session, pkt *ClientComMessage, sessOv
 	var changed bool
 	if target == asUid {
 		// Request new subscription or modify own subscription
-		changed, err = t.thisUserSub(h, sess, asUid, asLvl, pkt.id, set.Sub.Mode, nil, false, sessOverrides)
+		changed, err = t.thisUserSub(h, sess, asUid, asLvl, pkt.Id, set.Sub.Mode, nil, false, sessOverrides)
 	} else {
 		// Request to approve/change someone's subscription
 		changed, err = t.anotherUserSub(h, sess, asUid, target, set, sessOverrides)
@@ -2387,9 +2387,9 @@ func (t *Topic) replySetSub(h *Hub, sess *Session, pkt *ClientComMessage, sessOv
 		if target != asUid {
 			params["user"] = target.UserId()
 		}
-		resp = NoErrParams(pkt.id, toriginal, now, params)
+		resp = NoErrParams(pkt.Id, toriginal, now, params)
 	} else {
-		resp = InfoNotModified(pkt.id, toriginal, now)
+		resp = InfoNotModified(pkt.Id, toriginal, now)
 	}
 
 	sess.queueOutWithOverrides(resp, sessOverrides)

--- a/server/topic.go
+++ b/server/topic.go
@@ -215,7 +215,7 @@ func (t *Topic) runProxy(hub *Hub) {
 		case sreg := <-t.reg:
 			// Request to add a connection to this topic
 			if t.isInactive() {
-				asUid := types.ParseUserId(sreg.pkt.asUser)
+				asUid := types.ParseUserId(sreg.pkt.AsUser)
 				sreg.sess.queueOut(ErrLocked(sreg.pkt.Id, t.original(asUid), types.TimeNow()))
 			} else {
 				msg := &ProxyTopicMessage{
@@ -338,7 +338,7 @@ func (t *Topic) runProxy(hub *Hub) {
 									sreg := &sessionJoin{
 										sess: sess,
 										pkt: &ClientComMessage{
-											asUser:    msg.Uid.UserId(),
+											AsUser:    msg.Uid.UserId(),
 											timestamp: types.TimeNow(),
 										},
 									}
@@ -558,7 +558,7 @@ func (t *Topic) runLocal(hub *Hub) {
 			// Request to add a connection to this topic
 
 			if t.isInactive() {
-				asUid := types.ParseUserId(sreg.pkt.asUser)
+				asUid := types.ParseUserId(sreg.pkt.AsUser)
 				sreg.sess.queueOutWithOverrides(
 					ErrLocked(sreg.pkt.Id, t.original(asUid), types.TimeNow()), sreg.sessOverrides)
 			} else {
@@ -885,8 +885,8 @@ func (t *Topic) runLocal(hub *Hub) {
 
 		case meta := <-t.meta:
 			// Request to get/set topic metadata
-			asUid := types.ParseUserId(meta.pkt.asUser)
-			authLevel := auth.Level(meta.pkt.authLvl)
+			asUid := types.ParseUserId(meta.pkt.AsUser)
+			authLevel := auth.Level(meta.pkt.AuthLvl)
 			switch {
 			case meta.pkt.Get != nil:
 				// Get request
@@ -1048,7 +1048,7 @@ func (t *Topic) runLocal(hub *Hub) {
 // deferred notifications for the provided sessions.
 func (t *Topic) sendDeferredNotifications(joinReqs []*sessionJoin) {
 	for _, sreg := range joinReqs {
-		uid := types.ParseUserId(sreg.pkt.asUser)
+		uid := types.ParseUserId(sreg.pkt.AsUser)
 		if !t.isProxy {
 			pud := t.perUser[uid]
 			pud.online++
@@ -1063,7 +1063,7 @@ func (t *Topic) routeDeferredNotificationsToMaster(joinReqs []*sessionJoin) {
 	var sendReqs []*ProxyDeferredSession
 	for _, sreg := range joinReqs {
 		s := &ProxyDeferredSession{
-			AsUser:    sreg.pkt.asUser,
+			AsUser:    sreg.pkt.AsUser,
 			Sid:       sreg.sess.sid,
 			UserAgent: sreg.sess.userAgent,
 		}
@@ -1128,8 +1128,8 @@ func sidFromSessionOrOverrides(sess *Session, sessOverrides *sessionOverrides) s
 
 // Session subscribed to a topic, created == true if topic was just created and {pres} needs to be announced
 func (t *Topic) handleSubscription(h *Hub, sreg *sessionJoin) error {
-	asUid := types.ParseUserId(sreg.pkt.asUser)
-	authLevel := auth.Level(sreg.pkt.authLvl)
+	asUid := types.ParseUserId(sreg.pkt.AsUser)
+	authLevel := auth.Level(sreg.pkt.AuthLvl)
 
 	msgsub := sreg.pkt.Sub
 	getWhat := 0
@@ -1310,8 +1310,8 @@ func (t *Topic) subCommonReply(h *Hub, sreg *sessionJoin) error {
 	}
 
 	msgsub := sreg.pkt.Sub
-	asUid := types.ParseUserId(sreg.pkt.asUser)
-	asLvl := auth.Level(sreg.pkt.authLvl)
+	asUid := types.ParseUserId(sreg.pkt.AsUser)
+	asLvl := auth.Level(sreg.pkt.AuthLvl)
 	toriginal := t.original(asUid)
 
 	if !sreg.newsub && (t.cat == types.TopicCatP2P || t.cat == types.TopicCatGrp || t.cat == types.TopicCatSys) {
@@ -2346,8 +2346,8 @@ func (t *Topic) replyGetSub(sess *Session, asUid types.Uid, authLevel auth.Level
 func (t *Topic) replySetSub(h *Hub, sess *Session, pkt *ClientComMessage, sessOverrides *sessionOverrides) error {
 	now := types.TimeNow()
 
-	asUid := types.ParseUserId(pkt.asUser)
-	asLvl := auth.Level(pkt.authLvl)
+	asUid := types.ParseUserId(pkt.AsUser)
+	asLvl := auth.Level(pkt.AuthLvl)
 	set := pkt.Set
 	toriginal := t.original(asUid)
 

--- a/server/user.go
+++ b/server/user.go
@@ -14,7 +14,7 @@ import (
 func replyCreateUser(s *Session, msg *ClientComMessage, rec *auth.Rec) {
 	// The session cannot authenticate with the new account because  it's already authenticated.
 	if msg.Acc.Login && (!s.uid.IsZero() || rec != nil) {
-		s.queueOut(ErrAlreadyAuthenticated(msg.id, "", msg.timestamp))
+		s.queueOut(ErrAlreadyAuthenticated(msg.Id, "", msg.timestamp))
 		log.Println("create user: login requested while authenticated", s.sid)
 		return
 	}
@@ -23,7 +23,7 @@ func replyCreateUser(s *Session, msg *ClientComMessage, rec *auth.Rec) {
 	authhdl := store.GetLogicalAuthHandler(msg.Acc.Scheme)
 	if authhdl == nil {
 		// New accounts must have an authentication scheme
-		s.queueOut(ErrMalformed(msg.id, "", msg.timestamp))
+		s.queueOut(ErrMalformed(msg.Id, "", msg.timestamp))
 		log.Println("create user: unknown auth handler", s.sid)
 		return
 	}
@@ -31,7 +31,7 @@ func replyCreateUser(s *Session, msg *ClientComMessage, rec *auth.Rec) {
 	// Check if login is unique.
 	if ok, err := authhdl.IsUnique(msg.Acc.Secret); !ok {
 		log.Println("create user: auth secret is not unique", err, s.sid)
-		s.queueOut(decodeStoreError(err, msg.id, "", msg.timestamp,
+		s.queueOut(decodeStoreError(err, msg.Id, "", msg.timestamp,
 			map[string]interface{}{"what": "auth"}))
 		return
 	}
@@ -43,7 +43,7 @@ func replyCreateUser(s *Session, msg *ClientComMessage, rec *auth.Rec) {
 	if msg.Acc.State != "" {
 		if auth.Level(msg.authLvl) != auth.LevelRoot {
 			log.Println("create user: attempt to set account state by non-root", s.sid)
-			msg := ErrPermissionDenied(msg.id, "", msg.timestamp)
+			msg := ErrPermissionDenied(msg.Id, "", msg.timestamp)
 			msg.Ctrl.Params = map[string]interface{}{"what": "state"}
 			s.queueOut(msg)
 			return
@@ -52,7 +52,7 @@ func replyCreateUser(s *Session, msg *ClientComMessage, rec *auth.Rec) {
 		state, err := types.NewObjState(msg.Acc.State)
 		if err != nil || state == types.StateUndefined || state == types.StateDeleted {
 			log.Println("create user: invalid account state", err, s.sid)
-			s.queueOut(ErrMalformed(msg.id, "", msg.timestamp))
+			s.queueOut(ErrMalformed(msg.Id, "", msg.timestamp))
 			return
 		}
 		user.State = state
@@ -62,7 +62,7 @@ func replyCreateUser(s *Session, msg *ClientComMessage, rec *auth.Rec) {
 	if tags := normalizeTags(msg.Acc.Tags); tags != nil {
 		if !restrictedTagsEqual(tags, nil, globals.immutableTagNS) {
 			log.Println("create user: attempt to directly assign restricted tags", s.sid)
-			msg := ErrPermissionDenied(msg.id, "", msg.timestamp)
+			msg := ErrPermissionDenied(msg.Id, "", msg.timestamp)
 			msg.Ctrl.Params = map[string]interface{}{"what": "tags"}
 			s.queueOut(msg)
 			return
@@ -78,7 +78,7 @@ func replyCreateUser(s *Session, msg *ClientComMessage, rec *auth.Rec) {
 		vld := store.GetValidator(cr.Method)
 		if err := vld.PreCheck(cr.Value, cr.Params); err != nil {
 			log.Println("create user: failed credential pre-check", cr, err, s.sid)
-			s.queueOut(decodeStoreError(err, msg.Acc.Id, "", msg.timestamp,
+			s.queueOut(decodeStoreError(err, msg.Id, "", msg.timestamp,
 				map[string]interface{}{"what": cr.Method}))
 			return
 		}
@@ -117,7 +117,7 @@ func replyCreateUser(s *Session, msg *ClientComMessage, rec *auth.Rec) {
 	// Create user record in the database.
 	if _, err := store.Users.Create(&user, private); err != nil {
 		log.Println("create user: failed to create user", err, s.sid)
-		s.queueOut(ErrUnknown(msg.id, "", msg.timestamp))
+		s.queueOut(ErrUnknown(msg.Id, "", msg.timestamp))
 		return
 	}
 
@@ -127,7 +127,7 @@ func replyCreateUser(s *Session, msg *ClientComMessage, rec *auth.Rec) {
 		log.Println("create user: add auth record failed", err, s.sid)
 		// Attempt to delete incomplete user record
 		store.Users.Delete(user.Uid(), false)
-		s.queueOut(decodeStoreError(err, msg.id, "", msg.timestamp, nil))
+		s.queueOut(decodeStoreError(err, msg.Id, "", msg.timestamp, nil))
 		return
 	}
 
@@ -138,7 +138,7 @@ func replyCreateUser(s *Session, msg *ClientComMessage, rec *auth.Rec) {
 		// Attempt to delete incomplete user record
 		store.Users.Delete(user.Uid(), false)
 		_, missing := stringSliceDelta(globals.authValidators[rec.AuthLevel], credentialMethods(creds))
-		s.queueOut(decodeStoreError(types.ErrPolicy, msg.id, "", msg.timestamp,
+		s.queueOut(decodeStoreError(types.ErrPolicy, msg.Id, "", msg.timestamp,
 			map[string]interface{}{"creds": missing}))
 		return
 	}
@@ -154,7 +154,7 @@ func replyCreateUser(s *Session, msg *ClientComMessage, rec *auth.Rec) {
 		// Delete incomplete user record.
 		store.Users.Delete(user.Uid(), false)
 		log.Println("create user: failed to save or validate credential", err, s.sid)
-		s.queueOut(decodeStoreError(err, msg.id, "", msg.timestamp, nil))
+		s.queueOut(decodeStoreError(err, msg.Id, "", msg.timestamp, nil))
 		return
 	}
 
@@ -162,10 +162,10 @@ func replyCreateUser(s *Session, msg *ClientComMessage, rec *auth.Rec) {
 	if msg.Acc.Login {
 		// Process user's login request.
 		_, missing := stringSliceDelta(globals.authValidators[rec.AuthLevel], validated)
-		reply = s.onLogin(msg.id, msg.timestamp, rec, missing)
+		reply = s.onLogin(msg.Id, msg.timestamp, rec, missing)
 	} else {
 		// Not using the new account for logging in.
-		reply = NoErrCreated(msg.id, "", msg.timestamp)
+		reply = NoErrCreated(msg.Id, "", msg.timestamp)
 		reply.Ctrl.Params = map[string]interface{}{
 			"user":    user.Uid().UserId(),
 			"authlvl": rec.AuthLevel.String(),
@@ -193,12 +193,12 @@ func replyUpdateUser(s *Session, msg *ClientComMessage, rec *auth.Rec) {
 	if s.uid.IsZero() && rec == nil {
 		// Session is not authenticated and no token provided.
 		log.Println("replyUpdateUser: not a new account and not authenticated", s.sid)
-		s.queueOut(ErrPermissionDenied(msg.id, "", msg.timestamp))
+		s.queueOut(ErrPermissionDenied(msg.Id, "", msg.timestamp))
 		return
 	} else if msg.asUser != "" && rec != nil {
 		// Two UIDs: one from msg.from, one from token. Ambigous, reject.
 		log.Println("replyUpdateUser: got both authenticated session and token", s.sid)
-		s.queueOut(ErrMalformed(msg.id, "", msg.timestamp))
+		s.queueOut(ErrMalformed(msg.Id, "", msg.timestamp))
 		return
 	}
 
@@ -212,7 +212,7 @@ func replyUpdateUser(s *Session, msg *ClientComMessage, rec *auth.Rec) {
 	if msg.Acc.User != "" && msg.Acc.User != userId {
 		if s.authLvl != auth.LevelRoot {
 			log.Println("replyUpdateUser: attempt to change another's account by non-root", s.sid)
-			s.queueOut(ErrPermissionDenied(msg.id, "", msg.timestamp))
+			s.queueOut(ErrPermissionDenied(msg.Id, "", msg.timestamp))
 			return
 		}
 		// Root is editing someone else's account.
@@ -223,14 +223,14 @@ func replyUpdateUser(s *Session, msg *ClientComMessage, rec *auth.Rec) {
 	uid := types.ParseUserId(userId)
 	if uid.IsZero() {
 		// msg.Acc.User contains invalid data.
-		s.queueOut(ErrMalformed(msg.id, "", msg.timestamp))
+		s.queueOut(ErrMalformed(msg.Id, "", msg.timestamp))
 		log.Println("replyUpdateUser: user id is invalid or missing", s.sid)
 		return
 	}
 
 	// Only root can suspend accounts, including own account.
 	if msg.Acc.State != "" && s.authLvl != auth.LevelRoot {
-		s.queueOut(ErrPermissionDenied(msg.id, "", msg.timestamp))
+		s.queueOut(ErrPermissionDenied(msg.Id, "", msg.timestamp))
 		log.Println("replyUpdateUser: attempt to change account state by non-root", s.sid)
 		return
 	}
@@ -241,7 +241,7 @@ func replyUpdateUser(s *Session, msg *ClientComMessage, rec *auth.Rec) {
 	}
 	if err != nil {
 		log.Println("replyUpdateUser: failed to fetch user from DB", err, s.sid)
-		s.queueOut(decodeStoreError(err, msg.id, "", msg.timestamp, nil))
+		s.queueOut(decodeStoreError(err, msg.Id, "", msg.timestamp, nil))
 		return
 	}
 
@@ -251,7 +251,7 @@ func replyUpdateUser(s *Session, msg *ClientComMessage, rec *auth.Rec) {
 	} else if len(msg.Acc.Cred) > 0 {
 		if authLvl == auth.LevelNone {
 			// msg.Acc.AuthLevel contains invalid data.
-			s.queueOut(ErrMalformed(msg.id, "", msg.timestamp))
+			s.queueOut(ErrMalformed(msg.Id, "", msg.timestamp))
 			log.Println("replyUpdateUser: auth level is missing", s.sid)
 			return
 		}
@@ -278,7 +278,7 @@ func replyUpdateUser(s *Session, msg *ClientComMessage, rec *auth.Rec) {
 		var changed bool
 		changed, err = changeUserState(s, uid, user, msg)
 		if !changed && err == nil {
-			s.queueOut(InfoNotModified(msg.id, "", msg.timestamp))
+			s.queueOut(InfoNotModified(msg.Id, "", msg.timestamp))
 			return
 		}
 	} else {
@@ -287,11 +287,11 @@ func replyUpdateUser(s *Session, msg *ClientComMessage, rec *auth.Rec) {
 
 	if err != nil {
 		log.Println("replyUpdateUser: failed to update user", err, s.sid)
-		s.queueOut(decodeStoreError(err, msg.id, "", msg.timestamp, nil))
+		s.queueOut(decodeStoreError(err, msg.Id, "", msg.timestamp, nil))
 		return
 	}
 
-	s.queueOut(NoErrParams(msg.id, "", msg.timestamp, params))
+	s.queueOut(NoErrParams(msg.Id, "", msg.timestamp, params))
 
 	// Call plugin with the account update
 	pluginAccount(user, plgActUpd)
@@ -568,11 +568,11 @@ func replyDelUser(s *Session, msg *ClientComMessage) {
 		// Delete another user.
 		uid = types.ParseUserId(msg.Del.User)
 		if uid.IsZero() {
-			reply = ErrMalformed(msg.id, "", msg.timestamp)
+			reply = ErrMalformed(msg.Id, "", msg.timestamp)
 			log.Println("replyDelUser: invalid user ID", msg.Del.User, s.sid)
 		}
 	} else {
-		reply = ErrPermissionDenied(msg.id, "", msg.timestamp)
+		reply = ErrPermissionDenied(msg.Id, "", msg.timestamp)
 		log.Println("replyDelUser: illegal attempt to delete another user", msg.Del.User, s.sid)
 	}
 
@@ -616,10 +616,10 @@ func replyDelUser(s *Session, msg *ClientComMessage) {
 
 		// Delete user's records from the database.
 		if err := store.Users.Delete(uid, msg.Del.Hard); err != nil {
-			reply = decodeStoreError(err, msg.id, "", msg.timestamp, nil)
+			reply = decodeStoreError(err, msg.Id, "", msg.timestamp, nil)
 			log.Println("replyDelUser: failed to delete user", err, s.sid)
 		} else {
-			reply = NoErr(msg.id, "", msg.timestamp)
+			reply = NoErr(msg.Id, "", msg.timestamp)
 		}
 	}
 

--- a/server/user.go
+++ b/server/user.go
@@ -41,7 +41,7 @@ func replyCreateUser(s *Session, msg *ClientComMessage, rec *auth.Rec) {
 
 	// If account state is being assigned, make sure the sender is a root user.
 	if msg.Acc.State != "" {
-		if auth.Level(msg.authLvl) != auth.LevelRoot {
+		if auth.Level(msg.AuthLvl) != auth.LevelRoot {
 			log.Println("create user: attempt to set account state by non-root", s.sid)
 			msg := ErrPermissionDenied(msg.Id, "", msg.timestamp)
 			msg.Ctrl.Params = map[string]interface{}{"what": "state"}
@@ -195,15 +195,15 @@ func replyUpdateUser(s *Session, msg *ClientComMessage, rec *auth.Rec) {
 		log.Println("replyUpdateUser: not a new account and not authenticated", s.sid)
 		s.queueOut(ErrPermissionDenied(msg.Id, "", msg.timestamp))
 		return
-	} else if msg.asUser != "" && rec != nil {
+	} else if msg.AsUser != "" && rec != nil {
 		// Two UIDs: one from msg.from, one from token. Ambigous, reject.
 		log.Println("replyUpdateUser: got both authenticated session and token", s.sid)
 		s.queueOut(ErrMalformed(msg.Id, "", msg.timestamp))
 		return
 	}
 
-	userId := msg.asUser
-	authLvl := auth.Level(msg.authLvl)
+	userId := msg.AsUser
+	authLvl := auth.Level(msg.AuthLvl)
 	if rec != nil {
 		userId = rec.Uid.UserId()
 		authLvl = rec.AuthLevel


### PR DESCRIPTION
Made a bunch of fields in ClientComMessage serializable for intra-cluster communication and consequently they no longer have to be copied or inferred. 