### PR TITLE
Pass Session.countryCode to parseSearchQuery for better rewrites.

### DIFF
--- a/server/cluster.go
+++ b/server/cluster.go
@@ -99,6 +99,8 @@ type ClusterSess struct {
 
 	// Human language of the client
 	Lang string
+	// Country of the client
+	CountryCode string
 
 	// Device ID
 	DeviceID string
@@ -408,13 +410,14 @@ func (c *Cluster) TopicMaster(msg *ClusterReq, rejected *bool) error {
 			// Multiplexing session which actually handles the communication.
 			multi: msess,
 			// Local parameters specific to this session.
-			sid:        msg.Sess.Sid,
-			userAgent:  msg.Sess.UserAgent,
-			remoteAddr: msg.Sess.RemoteAddr,
-			lang:       msg.Sess.Lang,
-			proxyReq:   msg.ReqType,
-			background: msg.Sess.Background,
-			uid:        msg.Sess.Uid,
+			sid:         msg.Sess.Sid,
+			userAgent:   msg.Sess.UserAgent,
+			remoteAddr:  msg.Sess.RemoteAddr,
+			lang:        msg.Sess.Lang,
+			countryCode: msg.Sess.CountryCode,
+			proxyReq:    msg.ReqType,
+			background:  msg.Sess.Background,
+			uid:         msg.Sess.Uid,
 		}
 	}
 
@@ -710,16 +713,17 @@ func (c *Cluster) makeClusterReq(reqType ProxyReqType, payload interface{}, topi
 		}
 
 		req.Sess = &ClusterSess{
-			Uid:        uid,
-			AuthLvl:    sess.authLvl,
-			RemoteAddr: sess.remoteAddr,
-			UserAgent:  sess.userAgent,
-			Ver:        sess.ver,
-			Lang:       sess.lang,
-			DeviceID:   sess.deviceID,
-			Platform:   sess.platf,
-			Sid:        sess.sid,
-			Background: sess.background}
+			Uid:         uid,
+			AuthLvl:     sess.authLvl,
+			RemoteAddr:  sess.remoteAddr,
+			UserAgent:   sess.userAgent,
+			Ver:         sess.ver,
+			Lang:        sess.lang,
+			CountryCode: sess.countryCode,
+			DeviceID:    sess.deviceID,
+			Platform:    sess.platf,
+			Sid:         sess.sid,
+			Background:  sess.background}
 	}
 	return req
 }

--- a/server/main.go
+++ b/server/main.go
@@ -236,8 +236,9 @@ type configType struct {
 	// Take IP address of the client from HTTP header 'X-Forwarded-For'.
 	// Useful when tinode is behind a proxy. If missing, fallback to default RemoteAddr.
 	UseXForwardedFor bool `json:"use_x_forwarded_for"`
-	// 2-letter country code to assign to sessions by default when the country isn't specified
-	// by the client explicitly and it's impossible to infer it.
+	// 2-letter country code (ISO 3166-1 alpha-2) to assign to sessions by default
+	// when the country isn't specified by the client explicitly and
+	// it's impossible to infer it.
 	DefaultCountryCode string `json:"default_country_code"`
 
 	// Configs for subsystems

--- a/server/main.go
+++ b/server/main.go
@@ -99,6 +99,10 @@ const (
 
 	// Local path to static content
 	defaultStaticPath = "static"
+
+	// Default country code to fall back to if the "default_country_code" field
+	// isn't specified in the config.
+	defaultCountryCode = "US"
 )
 
 // Build version number defined by the compiler:
@@ -166,6 +170,9 @@ var globals struct {
 
 	// Prioritise X-Forwarded-For header as the source of IP address of the client.
 	useXForwardedFor bool
+
+	// Country code to assign to sessions by default.
+	defaultCountryCode string
 }
 
 type validatorConfig struct {
@@ -229,6 +236,9 @@ type configType struct {
 	// Take IP address of the client from HTTP header 'X-Forwarded-For'.
 	// Useful when tinode is behind a proxy. If missing, fallback to default RemoteAddr.
 	UseXForwardedFor bool `json:"use_x_forwarded_for"`
+	// 2-letter country code to assign to sessions by default when the country isn't specified
+	// by the client explicitly and it's impossible to infer it.
+	DefaultCountryCode string `json:"default_country_code"`
 
 	// Configs for subsystems
 	Cluster   json.RawMessage             `json:"cluster_config"`
@@ -468,6 +478,10 @@ func main() {
 	}
 
 	globals.useXForwardedFor = config.UseXForwardedFor
+	globals.defaultCountryCode = config.DefaultCountryCode
+	if globals.defaultCountryCode == "" {
+		globals.defaultCountryCode = defaultCountryCode
+	}
 
 	if config.Media != nil {
 		if config.Media.UseHandler == "" {

--- a/server/session.go
+++ b/server/session.go
@@ -23,6 +23,8 @@ import (
 	"github.com/tinode/chat/server/auth"
 	"github.com/tinode/chat/server/store"
 	"github.com/tinode/chat/server/store/types"
+
+	"golang.org/x/text/language"
 )
 
 // Wait time before abandoning the outbound send operation.
@@ -95,6 +97,8 @@ type Session struct {
 	platf string
 	// Human language of the client
 	lang string
+	// Country code of the client
+	countryCode string
 
 	// ID of the current user. Could be zero if session is not authenticated
 	// or for multiplexing sessions.
@@ -630,6 +634,15 @@ func (s *Session) hello(msg *ClientComMessage) {
 	}
 	s.deviceID = msg.Hi.DeviceID
 	s.lang = msg.Hi.Lang
+	// Try to deduce the country from the locale.
+	if tag, err := language.Parse(s.lang); err == nil {
+		if region, conf := tag.Region(); region.IsCountry() && conf >= language.High {
+			s.countryCode = region.String()
+		}
+	}
+	if s.countryCode == "" {
+		s.countryCode = globals.defaultCountryCode
+	}
 
 	var httpStatus int
 	var httpStatusText string

--- a/server/session.go
+++ b/server/session.go
@@ -641,6 +641,11 @@ func (s *Session) hello(msg *ClientComMessage) {
 		}
 	}
 	if s.countryCode == "" {
+		if len(s.lang) > 2 {
+			// Logging strings longer than 2 b/c language.Parse(XX) always succeeds
+			// returning confidence Low.
+			log.Println("s.hello:", "could not parse locale ", s.lang)
+		}
 		s.countryCode = globals.defaultCountryCode
 	}
 

--- a/server/tinode.conf
+++ b/server/tinode.conf
@@ -50,6 +50,11 @@
 	// Useful when tinode is behind a proxy. If missing, fallback to default RemoteAddr.
 	"use_x_forwarded_for": true,
 
+	// 2-letter country code to assign to sessions by default when the country isn't specified
+	// by the client explicitly and it's impossible to infer it.
+	// If missing, the server will default to "US".
+	"default_country_code": "",
+
 	// Large media/blob handlers.
 	"media": {
 		// Media handler to use

--- a/server/topic.go
+++ b/server/topic.go
@@ -1793,7 +1793,7 @@ func (t *Topic) replyGetSub(sess *Session, asUid types.Uid, authLevel auth.Level
 			if err == nil && subs == nil && query != "" {
 				var req [][]string
 				var opt []string
-				if req, opt, err = parseSearchQuery(query); err == nil {
+				if req, opt, err = parseSearchQuery(query, sess.countryCode); err == nil {
 					if len(req) > 0 || len(opt) > 0 {
 						// Check if the query contains terms that the user is not allowed to use.
 						allReq := types.FlattenDoubleSlice(req)

--- a/server/utils.go
+++ b/server/utils.go
@@ -403,7 +403,7 @@ func versionToString(vers int) string {
 // rewriteToken attempts to match the original token
 // against the email, telephone number or login patterns.
 // On success, prepends the token with the corresponding prefix.
-func rewriteToken(orig string) string {
+func rewriteToken(orig, countryCode string) string {
 	if orig == "" || alnumPrefixRegexp.MatchString(orig) {
 		// It either empty or already has a prefix. E.g. basic:alice.
 		return orig
@@ -417,7 +417,7 @@ func rewriteToken(orig string) string {
 	//    from client's phone number or location).
 	// 2. Use value from .conf file.
 	// 3. Fallback to US as a last resort.
-	if num, err := phonenumbers.Parse(orig, "US"); err == nil {
+	if num, err := phonenumbers.Parse(orig, countryCode); err == nil {
 		// It's a phone number.
 		return "tel:" + phonenumbers.Format(num, phonenumbers.E164)
 	}
@@ -444,7 +444,7 @@ func rewriteToken(orig string) string {
 // characters, i.e. length of string in bytes != length of string in runes.
 // Returns AND of ORs of tags (at least one of each sublist must be present in every result),
 // OR tags (one or more present), error.
-func parseSearchQuery(query string) ([][]string, []string, error) {
+func parseSearchQuery(query, countryCode string) ([][]string, []string, error) {
 	const (
 		NONE = iota
 		QUO
@@ -568,7 +568,7 @@ func parseSearchQuery(query string) ([][]string, []string, error) {
 			// Add token if non-empty.
 			if start < end {
 				original := query[start:end]
-				rewritten := rewriteToken(original)
+				rewritten := rewriteToken(original, countryCode)
 				t := token{val: original, op: op}
 				if rewritten != original {
 					t.rewrittenVal = rewritten


### PR DESCRIPTION
Parse country code from the client provided language/locale.
If it fails, fall back to the default country code specified in tinode config.