### PR TITLE
Set defaultMaxMessageResults to 100 in DB adapters.

### DIFF
--- a/server/db/mongodb/adapter.go
+++ b/server/db/mongodb/adapter.go
@@ -43,8 +43,9 @@ const (
 	adpVersion  = 111
 	adapterName = "mongodb"
 
+	defaultMaxResults = 1024
 	// This is capped by the Session's send queue limit (128).
-	defaultMaxResults = 100
+	defaultMaxMessageResults = 100
 )
 
 // See https://godoc.org/go.mongodb.org/mongo-driver/mongo/options#ClientOptions for explanations.
@@ -1963,7 +1964,7 @@ func (a *adapter) MessageDeleteList(topic string, toDel *t.DelMessage) error {
 
 // MessageGetDeleted returns a list of deleted message Ids.
 func (a *adapter) MessageGetDeleted(topic string, forUser t.Uid, opts *t.QueryOpt) ([]t.DelMessage, error) {
-	var limit = a.maxMessageResults
+	var limit = a.maxResults
 	var lower, upper int
 	if opts != nil {
 		if opts.Since > 0 {

--- a/server/db/mongodb/adapter.go
+++ b/server/db/mongodb/adapter.go
@@ -24,13 +24,16 @@ import (
 
 // adapter holds MongoDB connection data.
 type adapter struct {
-	conn            *mdb.Client
-	db              *mdb.Database
-	dbName          string
-	maxResults      int
-	version         int
-	ctx             context.Context
-	useTransactions bool
+	conn              *mdb.Client
+	db                *mdb.Database
+	dbName            string
+	// Maximum number of records to return
+	maxResults        int
+	// Maximum number of message records to return
+	maxMessageResults int
+	version           int
+	ctx               context.Context
+	useTransactions   bool
 }
 
 const (
@@ -137,6 +140,10 @@ func (a *adapter) Open(jsonconfig json.RawMessage) error {
 
 	if a.maxResults <= 0 {
 		a.maxResults = defaultMaxResults
+	}
+
+	if a.maxMessageResults <= 0 {
+		a.maxMessageResults = defaultMaxMessageResults
 	}
 
 	a.ctx = context.Background()
@@ -1818,7 +1825,7 @@ func (a *adapter) MessageSave(msg *t.Message) error {
 
 // MessageGetAll returns messages matching the query
 func (a *adapter) MessageGetAll(topic string, forUser t.Uid, opts *t.QueryOpt) ([]t.Message, error) {
-	var limit = a.maxResults
+	var limit = a.maxMessageResults
 	var lower, upper int
 	requester := forUser.String()
 	if opts != nil {
@@ -1956,7 +1963,7 @@ func (a *adapter) MessageDeleteList(topic string, toDel *t.DelMessage) error {
 
 // MessageGetDeleted returns a list of deleted message Ids.
 func (a *adapter) MessageGetDeleted(topic string, forUser t.Uid, opts *t.QueryOpt) ([]t.DelMessage, error) {
-	var limit = a.maxResults
+	var limit = a.maxMessageResults
 	var lower, upper int
 	if opts != nil {
 		if opts.Since > 0 {

--- a/server/db/mongodb/adapter.go
+++ b/server/db/mongodb/adapter.go
@@ -40,7 +40,8 @@ const (
 	adpVersion  = 111
 	adapterName = "mongodb"
 
-	defaultMaxResults = 1024
+	// This is capped by the Session's send queue limit (128).
+	defaultMaxResults = 100
 )
 
 // See https://godoc.org/go.mongodb.org/mongo-driver/mongo/options#ClientOptions for explanations.

--- a/server/db/mysql/adapter.go
+++ b/server/db/mysql/adapter.go
@@ -37,7 +37,8 @@ const (
 
 	adapterName = "mysql"
 
-	defaultMaxResults = 1024
+	// This is capped by the Session's send queue limit (128).
+	defaultMaxResults = 100
 )
 
 type configType struct {

--- a/server/db/mysql/adapter.go
+++ b/server/db/mysql/adapter.go
@@ -21,12 +21,14 @@ import (
 
 // adapter holds MySQL connection data.
 type adapter struct {
-	db     *sqlx.DB
-	dsn    string
-	dbName string
+	db                *sqlx.DB
+	dsn               string
+	dbName            string
 	// Maximum number of records to return
-	maxResults int
-	version    int
+	maxResults        int
+	// Maximum number of message records to return
+	maxMessageResults int
+	version           int
 }
 
 const (
@@ -37,8 +39,9 @@ const (
 
 	adapterName = "mysql"
 
+	defaultMaxResults = 1024
 	// This is capped by the Session's send queue limit (128).
-	defaultMaxResults = 100
+	defaultMaxMessageResults = 100
 )
 
 type configType struct {
@@ -71,6 +74,10 @@ func (a *adapter) Open(jsonconfig json.RawMessage) error {
 
 	if a.maxResults <= 0 {
 		a.maxResults = defaultMaxResults
+	}
+
+	if a.maxMessageResults <= 0 {
+		a.maxMessageResults = defaultMaxMessageResults
 	}
 
 	// This just initializes the driver but does not open the network connection.
@@ -2028,7 +2035,7 @@ func (a *adapter) MessageSave(msg *t.Message) error {
 }
 
 func (a *adapter) MessageGetAll(topic string, forUser t.Uid, opts *t.QueryOpt) ([]t.Message, error) {
-	var limit = a.maxResults
+	var limit = a.maxMessageResults
 	var lower = 0
 	var upper = 1<<31 - 1
 
@@ -2083,7 +2090,7 @@ var dellog struct {
 
 // Get ranges of deleted messages
 func (a *adapter) MessageGetDeleted(topic string, forUser t.Uid, opts *t.QueryOpt) ([]t.DelMessage, error) {
-	var limit = a.maxResults
+	var limit = a.maxMessageResults
 	var lower = 0
 	var upper = 1<<31 - 1
 

--- a/server/db/mysql/adapter.go
+++ b/server/db/mysql/adapter.go
@@ -2090,7 +2090,7 @@ var dellog struct {
 
 // Get ranges of deleted messages
 func (a *adapter) MessageGetDeleted(topic string, forUser t.Uid, opts *t.QueryOpt) ([]t.DelMessage, error) {
-	var limit = a.maxMessageResults
+	var limit = a.maxResults
 	var lower = 0
 	var upper = 1<<31 - 1
 

--- a/server/db/rethinkdb/adapter.go
+++ b/server/db/rethinkdb/adapter.go
@@ -33,7 +33,8 @@ const (
 
 	adapterName = "rethinkdb"
 
-	defaultMaxResults = 1024
+	// This is capped by the Session's send queue limit (128).
+	defaultMaxResults = 100
 )
 
 // See https://godoc.org/github.com/rethinkdb/rethinkdb-go#ConnectOpts for explanations.

--- a/server/db/rethinkdb/adapter.go
+++ b/server/db/rethinkdb/adapter.go
@@ -19,10 +19,13 @@ import (
 
 // adapter holds RethinkDb connection data.
 type adapter struct {
-	conn       *rdb.Session
-	dbName     string
-	maxResults int
-	version    int
+	conn              *rdb.Session
+	dbName            string
+	// Maximum number of records to return
+	maxResults        int
+	// Maximum number of message records to return
+	maxMessageResults int
+	version           int
 }
 
 const (
@@ -33,8 +36,9 @@ const (
 
 	adapterName = "rethinkdb"
 
+	defaultMaxResults = 1024
 	// This is capped by the Session's send queue limit (128).
-	defaultMaxResults = 100
+	defaultMaxMessageResults = 100
 )
 
 // See https://godoc.org/github.com/rethinkdb/rethinkdb-go#ConnectOpts for explanations.
@@ -89,6 +93,10 @@ func (a *adapter) Open(jsonconfig json.RawMessage) error {
 
 	if a.maxResults <= 0 {
 		a.maxResults = defaultMaxResults
+	}
+
+	if a.maxMessageResults <= 0 {
+		a.maxMessageResults = defaultMaxMessageResults
 	}
 
 	opts.Database = a.dbName
@@ -1660,7 +1668,7 @@ func (a *adapter) MessageSave(msg *t.Message) error {
 
 func (a *adapter) MessageGetAll(topic string, forUser t.Uid, opts *t.QueryOpt) ([]t.Message, error) {
 
-	var limit = a.maxResults
+	var limit = a.maxMessageResults
 	var lower, upper interface{}
 
 	upper = rdb.MaxVal
@@ -1712,7 +1720,7 @@ func (a *adapter) MessageGetAll(topic string, forUser t.Uid, opts *t.QueryOpt) (
 
 // Get ranges of deleted messages
 func (a *adapter) MessageGetDeleted(topic string, forUser t.Uid, opts *t.QueryOpt) ([]t.DelMessage, error) {
-	var limit = a.maxResults
+	var limit = a.maxMessageResults
 	var lower, upper interface{}
 
 	upper = rdb.MaxVal

--- a/server/db/rethinkdb/adapter.go
+++ b/server/db/rethinkdb/adapter.go
@@ -1720,7 +1720,7 @@ func (a *adapter) MessageGetAll(topic string, forUser t.Uid, opts *t.QueryOpt) (
 
 // Get ranges of deleted messages
 func (a *adapter) MessageGetDeleted(topic string, forUser t.Uid, opts *t.QueryOpt) ([]t.DelMessage, error) {
-	var limit = a.maxMessageResults
+	var limit = a.maxResults
 	var lower, upper interface{}
 
 	upper = rdb.MaxVal


### PR DESCRIPTION
Fetching more cannot will result in overwhelming the send queues
which effectively leads to session termination.

It's one of the problems that prevented us from running valid loadtests.