### PR TITLE
Fix security flaw that attacker can change password of any user.

### DIFF
--- a/server/auth/basic/auth_basic.go
+++ b/server/auth/basic/auth_basic.go
@@ -170,7 +170,7 @@ func (a *authenticator) UpdateRecord(rec *auth.Rec, secret []byte) (*auth.Rec, e
 	} else if uid, _, _, _, err := store.Users.GetAuthUniqueRecord(a.name, uname); err != nil {
 		return nil, err
 	} else if !uid.IsZero() {
-		// .User is changing unique name, check for duplicate unique name
+		// The (new) user name already exists. Report an error.
 		return nil, types.ErrDuplicate
 	}
 

--- a/server/auth/basic/auth_basic.go
+++ b/server/auth/basic/auth_basic.go
@@ -167,6 +167,11 @@ func (a *authenticator) UpdateRecord(rec *auth.Rec, secret []byte) (*auth.Rec, e
 		uname = login
 	} else if err = a.checkLoginPolicy(uname); err != nil {
 		return nil, err
+	} else if uid, _, _, _, err := store.Users.GetAuthUniqueRecord(a.name, uname); err != nil {
+		return nil, err
+	} else if !uid.IsZero() {
+		// .User is changing unique name, check for duplicate unique name
+		return nil, types.ErrDuplicate
 	}
 
 	if err = a.checkPasswordPolicy(password); err != nil {

--- a/server/db/mysql/adapter.go
+++ b/server/db/mysql/adapter.go
@@ -719,8 +719,8 @@ func (a *adapter) AuthUpdRecord(uid t.Uid, scheme, unique string, authLvl auth.L
 		exp = &expires
 	}
 
-	_, err := a.db.Exec("UPDATE auth SET uname=?,authLvl=?,secret=?,expires=? WHERE uname=?",
-		unique, authLvl, secret, exp, unique)
+	_, err := a.db.Exec("UPDATE auth SET uname=?,authLvl=?,secret=?,expires=? WHERE userid=? AND scheme=?",
+		unique, authLvl, secret, exp, store.DecodeUid(uid), scheme)
 	if isDupe(err) {
 		return t.ErrDuplicate
 	}


### PR DESCRIPTION
Attacker can try to send a changing password request along with the uname of another existing user.
BasicAuthenticator.UpdateRecord did not check the existing of the uname.
MySQL adapter also blindly update the record of another user to the new password.