### PR TITLE
Introduce histogram expvar.Var for latency tracking.

### DIFF
--- a/server/hub.go
+++ b/server/hub.go
@@ -20,6 +20,10 @@ import (
 	"github.com/tinode/chat/server/store/types"
 )
 
+// Request latency distribution bounds (in milliseconds).
+// "var" because Go does not support array constants.
+var RequestLatencyDistribution = [...]float64 {1, 2, 3, 4, 5, 6, 8, 10, 13, 16, 20, 25, 30, 40, 50, 65, 80, 100, 130, 160, 200, 250, 300, 400, 500, 650, 800, 1000, 2000, 5000, 10000, 20000, 50000, 100000,}
+
 // Request to hub to subscribe session to topic
 type sessionJoin struct {
 	// Message, containing request details.
@@ -129,6 +133,8 @@ func newHub() *Hub {
 
 	statsRegisterInt("FileDownloadsTotal")
 	statsRegisterInt("FileUploadsTotal")
+
+	statsRegisterHistogram("RequestLatency", RequestLatencyDistribution[:]...)
 
 	go h.run()
 

--- a/server/hub.go
+++ b/server/hub.go
@@ -22,7 +22,7 @@ import (
 
 // Request latency distribution bounds (in milliseconds).
 // "var" because Go does not support array constants.
-var RequestLatencyDistribution = [...]float64 {1, 2, 3, 4, 5, 6, 8, 10, 13, 16, 20, 25, 30, 40, 50, 65, 80, 100, 130, 160, 200, 250, 300, 400, 500, 650, 800, 1000, 2000, 5000, 10000, 20000, 50000, 100000,}
+var RequestLatencyDistribution = []float64{1, 2, 3, 4, 5, 6, 8, 10, 13, 16, 20, 25, 30, 40, 50, 65, 80, 100, 130, 160, 200, 250, 300, 400, 500, 650, 800, 1000, 2000, 5000, 10000, 20000, 50000, 100000}
 
 // Request to hub to subscribe session to topic
 type sessionJoin struct {
@@ -134,7 +134,7 @@ func newHub() *Hub {
 	statsRegisterInt("FileDownloadsTotal")
 	statsRegisterInt("FileUploadsTotal")
 
-	statsRegisterHistogram("RequestLatency", RequestLatencyDistribution[:]...)
+	statsRegisterHistogram("RequestLatency", RequestLatencyDistribution)
 
 	go h.run()
 

--- a/server/session.go
+++ b/server/session.go
@@ -256,7 +256,7 @@ func (s *Session) queueOut(msg *ServerComMessage) bool {
 	// Record latency only on {ctrl} messages and end-user sessions.
 	if msg.Ctrl != nil && msg.Id != "" && !msg.Ctrl.Timestamp.IsZero() && !s.isCluster() {
 		duration := time.Since(msg.Ctrl.Timestamp).Milliseconds()
-		statsAddSample("RequestLatency", float64(duration))
+		statsAddHistSample("RequestLatency", float64(duration))
 	}
 
 	select {


### PR DESCRIPTION
Latencies are defined as the time between the receipt of a client request (e.g. `{pub}`) and the moment the server replies with a `{ctrl}` to this client request.
Latencies are exported as a histogram with a predefined (hardcoded) set of buckets.
Samples are recorded upon writing out `{ctrl}` messages with the specified `Id` and `Timestamp` (expected to be the timestamp of the original client request receipt) fields.

This PR currently does not address the following issues (to be implemented in follow-up PRs & commits):
1. `Timestamp` value may not be the actual original request receipt ts (e.g. https://github.com/tinode/chat/blob/11d514b58a1b5d7a3bbc67db55fa088394c73e7c/server/hub.go#L215)
2. Latencies won't be measured correctly in the cluster mode (for requests that require communicating the topic master sitting on another node).