### PR TITLE
Subscribing/unsubscribing to FCM topics

### DIFF
--- a/server/push/fcm/payload.go
+++ b/server/push/fcm/payload.go
@@ -332,3 +332,22 @@ func PrepareNotifications(rcpt *push.Receipt, config *AndroidConfig) []MessageDa
 
 	return messages
 }
+
+// DevicesForUser loads device IDs of the given user.
+func DevicesForUser(uid t.Uid) []string {
+	ddef, count, err := store.Devices.GetAll(uid)
+	if err != nil {
+		log.Println("fcm devices for user: db error", err)
+		return nil
+	}
+
+	if count == 0 {
+		return nil
+	}
+
+	devices := make([]string, count)
+	for i, dd := range ddef[uid] {
+		devices[i] = dd.DeviceId
+	}
+	return devices
+}

--- a/server/push/fcm/push_fcm.go
+++ b/server/push/fcm/push_fcm.go
@@ -152,6 +152,7 @@ func processSubscription(req *push.ChannelReq) {
 	if len(devices) > subBatchSize {
 		// It's extremely unlikely for a single user to have this many devices.
 		devices = devices[0:subBatchSize]
+		log.Println("fcm: user has more than", subBatchSize, "devices")
 	}
 
 	var err error
@@ -163,7 +164,7 @@ func processSubscription(req *push.ChannelReq) {
 	}
 	if err != nil {
 		// Complete failure.
-		log.Println("fcm sub or upsub failed", req.Unsub, err)
+		log.Println("fcm: sub or upsub failed", req.Unsub, err)
 	} else {
 		// Check for partial failure.
 		handleSubErrors(resp, req.Uid, devices)

--- a/server/push/fcm/push_fcm.go
+++ b/server/push/fcm/push_fcm.go
@@ -150,7 +150,6 @@ func processSubscription(req *push.ChannelReq) {
 
 	if len(req.Devices) > subBatchSize {
 		// It's extremely unlikely for a single user to have this many devices.
-		// Just clipping the list.
 		req.Devices = req.Devices[0:subBatchSize]
 	}
 

--- a/server/push/fcm/push_fcm.go
+++ b/server/push/fcm/push_fcm.go
@@ -144,28 +144,29 @@ func sendNotifications(rcpt *push.Receipt, config *configType) {
 }
 
 func processSubscription(req *push.ChannelReq) {
-	if len(req.Devices) == 0 {
+	devices := DevicesForUser(req.Uid)
+	if len(devices) == 0 {
 		return
 	}
 
-	if len(req.Devices) > subBatchSize {
+	if len(devices) > subBatchSize {
 		// It's extremely unlikely for a single user to have this many devices.
-		req.Devices = req.Devices[0:subBatchSize]
+		devices = devices[0:subBatchSize]
 	}
 
 	var err error
 	var resp *fcm.TopicManagementResponse
 	if req.Unsub {
-		resp, err = handler.client.UnsubscribeFromTopic(context.Background(), req.Devices, req.Channel)
+		resp, err = handler.client.UnsubscribeFromTopic(context.Background(), devices, req.Channel)
 	} else {
-		resp, err = handler.client.SubscribeToTopic(context.Background(), req.Devices, req.Channel)
+		resp, err = handler.client.SubscribeToTopic(context.Background(), devices, req.Channel)
 	}
 	if err != nil {
 		// Complete failure.
 		log.Println("fcm sub or upsub failed", req.Unsub, err)
 	} else {
 		// Check for partial failure.
-		handleSubErrors(resp, req.Uid, req.Devices)
+		handleSubErrors(resp, req.Uid, devices)
 	}
 }
 

--- a/server/push/fcm/push_fcm.go
+++ b/server/push/fcm/push_fcm.go
@@ -152,7 +152,7 @@ func processSubscription(req *push.ChannelReq) {
 	if len(devices) > subBatchSize {
 		// It's extremely unlikely for a single user to have this many devices.
 		devices = devices[0:subBatchSize]
-		log.Println("fcm: user has more than", subBatchSize, "devices")
+		log.Println("fcm: user", req.Uid.UserId(), "has more than", subBatchSize, "devices")
 	}
 
 	var err error

--- a/server/push/push.go
+++ b/server/push/push.go
@@ -43,8 +43,6 @@ type ChannelReq struct {
 	Uid t.Uid `json:"-"`
 	// Channel to subscribe to or unsubscribe from.
 	Channel string `json:"channel"`
-	// Devices to subscribe or unsubscribe.
-	Devices []string `json:"devices"`
 	// Unsub is set to true to unsubscribe devices, otherwise subscribe them.
 	Unsub bool `json:"unsub"`
 }

--- a/server/push/tnpg/push_tnpg.go
+++ b/server/push/tnpg/push_tnpg.go
@@ -219,7 +219,7 @@ func processSubscription(req *push.ChannelReq, config *configType) {
 	if len(su.Devices) > subBatchSize {
 		// It's extremely unlikely for a single user to have this many devices.
 		su.Devices = su.Devices[0:subBatchSize]
-		log.Println("tnpg: user has more than", subBatchSize, "devices")
+		log.Println("tnpg: user", req.Uid.UserId(), "has more than", subBatchSize, "devices")
 	}
 
 	resp, err := postMessage(&su, config)

--- a/server/store/store.go
+++ b/server/store/store.go
@@ -822,7 +822,8 @@ func (DeviceMapper) Update(uid types.Uid, oldDeviceID string, dev *types.DeviceD
 	return nil
 }
 
-// GetAll returns all known device IDS for a given list of user IDs.
+// GetAll returns all known device IDs for a given list of user IDs.
+// The second return parameter is the count of found device IDs.
 func (DeviceMapper) GetAll(uid ...types.Uid) (map[types.Uid][]types.DeviceDef, int, error) {
 	return adp.DeviceGetAll(uid...)
 }

--- a/server/topic.go
+++ b/server/topic.go
@@ -1003,7 +1003,6 @@ func (t *Topic) handleBroadcast(msg *ServerComMessage) {
 		// usersPush will update unread message count and send push notification.
 		usersPush(pushRcpt)
 	}
-
 }
 
 // subscriptionReply generates a response to a subscription request
@@ -2892,6 +2891,10 @@ func (t *Topic) pushForData(fromUid types.Uid, data *MsgServerData) *push.Receip
 			ContentType: contentType,
 			Content:     data.Content}}
 
+	if t.isChan {
+		receipt.Channel = types.GrpToChn(t.xoriginal)
+	}
+
 	for uid, pud := range t.perUser {
 		// Send only to those who have notifications enabled, exclude the originating user.
 		if uid == fromUid {
@@ -2906,7 +2909,7 @@ func (t *Topic) pushForData(fromUid types.Uid, data *MsgServerData) *push.Receip
 			}
 		}
 	}
-	if len(receipt.To) > 0 {
+	if len(receipt.To) > 0 || receipt.Channel != "" {
 		return &receipt
 	}
 	// If there are no recipient there is no need to send the push notification.

--- a/server/topic.go
+++ b/server/topic.go
@@ -3282,13 +3282,13 @@ func (t *Topic) isOnline() bool {
 // Verifies if topic can be access by the given name.
 // Returns true if access is for channel, false if not and error if access is invalid.
 func (t *Topic) verifyChannelAccess(asTopic string) (bool, error) {
-	if isChannel(asTopic) {
-		if t.isChan {
-			return true, nil
-		}
-		return false, types.ErrNotFound
+	if !isChannel(asTopic) {
+		return false, nil
 	}
-	return false, nil
+	if t.isChan {
+		return true, nil
+	}
+	return false, types.ErrNotFound
 }
 
 // Infer topic category from name.

--- a/server/user.go
+++ b/server/user.go
@@ -722,10 +722,12 @@ func usersPush(rcpt *push.Receipt) {
 	if globals.cluster != nil {
 		local = &UserCacheReq{PushRcpt: &push.Receipt{
 			Payload: rcpt.Payload,
+			Channel: rcpt.Channel,
 			To:      make(map[types.Uid]push.Recipient),
 		}}
 		remote := &UserCacheReq{PushRcpt: &push.Receipt{
 			Payload: rcpt.Payload,
+			Channel: rcpt.Channel,
 			To:      make(map[types.Uid]push.Recipient),
 		}}
 
@@ -737,14 +739,14 @@ func usersPush(rcpt *push.Receipt) {
 			}
 		}
 
-		if len(remote.PushRcpt.To) > 0 {
+		if len(remote.PushRcpt.To) > 0 || remote.PushRcpt.Channel != "" {
 			globals.cluster.routeUserReq(remote)
 		}
 	} else {
 		local = &UserCacheReq{PushRcpt: rcpt}
 	}
 
-	if len(local.PushRcpt.To) > 0 {
+	if len(local.PushRcpt.To) > 0 || local.PushRcpt.Channel != "" {
 		select {
 		case globals.usersUpdate <- local:
 		default:
@@ -895,7 +897,6 @@ func userUpdater() {
 					upd.PushRcpt.To[uid] = rcptTo
 				}
 			}
-
 			push.Push(upd.PushRcpt)
 			continue
 		}


### PR DESCRIPTION
Mostly done.

Missing: 
1. Subscribe/unsubscribe to FCM topics in response to changes to P permission.
~2. Send push to user's devices when the user subscribes to a channel.~ -- done
3. Allow admins to delete channel subscriptions.
4. Maybe allow admins to add users to channels, but I'm not sure. Could be too spammy.