### PR TITLE
Fail subscribe requests when the Hub's join queue is full.

### DIFF
--- a/loadtest/tsung.xml
+++ b/loadtest/tsung.xml
@@ -105,6 +105,7 @@
           <thinktime value="3" random="true"></thinktime>
 
           <request subst="true">
+            <match do="abort" when="nomatch">{"ctrl":.*"code":200.*}</match>
             <websocket type="message" frame="text">{"sub":{"id":"%%_baseid%%%%_topicx%%%%_ctr%%","topic":"%%_topicx%%","get":{"what":"desc sub data del"}}}</websocket>
           </request>
 

--- a/server/hub.go
+++ b/server/hub.go
@@ -78,10 +78,10 @@ type Hub struct {
 	// Channel for routing messages between topics, buffered at 4096
 	route chan *ServerComMessage
 
-	// subscribe session to topic, possibly creating a new topic, unbuffered
+	// subscribe session to topic, possibly creating a new topic, buffered at 32
 	join chan *sessionJoin
 
-	// Remove topic from hub, possibly deleting it afterwards, unbuffered
+	// Remove topic from hub, possibly deleting it afterwards, buffered at 32
 	unreg chan *topicUnreg
 
 	// Process get.info requests for topic not subscribed to, buffered 128

--- a/server/hub.go
+++ b/server/hub.go
@@ -114,8 +114,8 @@ func newHub() *Hub {
 		topics: &sync.Map{},
 		// this needs to be buffered - hub generates invites and adds them to this queue
 		route:    make(chan *ServerComMessage, 4096),
-		join:     make(chan *sessionJoin),
-		unreg:    make(chan *topicUnreg),
+		join:     make(chan *sessionJoin, 32),
+		unreg:    make(chan *topicUnreg, 32),
 		rehash:   make(chan bool),
 		meta:     make(chan *metaReq, 128),
 		shutdown: make(chan chan<- bool),


### PR DESCRIPTION
Handle subscribe responses in tsung.xml in such cases.
Also, gofmt on session.go.