### PR TITLE
Break Session.writeLoop() in session cleanup.

### DIFF
--- a/server/hdl_longpoll.go
+++ b/server/hdl_longpoll.go
@@ -45,7 +45,9 @@ func (sess *Session) writeOnce(wrt http.ResponseWriter, req *http.Request) {
 			// Request to close the session. Make it unavailable.
 			globals.sessionStore.Delete(sess)
 			// Don't care if lpWrite fails.
-			lpWrite(wrt, msg)
+			if msg != nil {
+				lpWrite(wrt, msg)
+			}
 			return
 
 		case topic := <-sess.detach:

--- a/server/session.go
+++ b/server/session.go
@@ -305,6 +305,8 @@ func (s *Session) cleanUp(expired bool) {
 	s.background = false
 	s.bkgTimer.Stop()
 	s.unsubAll()
+	// Stop the write loop.
+	s.stop <- nil
 }
 
 // Message received, convert bytes to ClientComMessage and dispatch


### PR DESCRIPTION
Write loop continues to run after its host session quits. Fix it.