### PR TITLE
Explicitly specify uid in proxy leave requests.

### DIFF
--- a/server/hub.go
+++ b/server/hub.go
@@ -180,7 +180,7 @@ func (h *Hub) run() {
 					xoriginal: join.pkt.Original,
 					// Indicates a proxy topic.
 					isProxy:   globals.cluster.isRemoteTopic(join.pkt.RcptTo),
-					sessions:  make(map[*Session]*perSessionData),
+					sessions:  make(map[*Session]perSessionData),
 					broadcast: make(chan *ServerComMessage, 256),
 					reg:       make(chan *sessionJoin, 32),
 					unreg:     make(chan *sessionLeave, 32),

--- a/server/hub.go
+++ b/server/hub.go
@@ -180,7 +180,7 @@ func (h *Hub) run() {
 					xoriginal: join.pkt.Original,
 					// Indicates a proxy topic.
 					isProxy:   globals.cluster.isRemoteTopic(join.pkt.RcptTo),
-					sessions:  make(map[*Session]perSessionData),
+					sessions:  make(map[*Session]*perSessionData),
 					broadcast: make(chan *ServerComMessage, 256),
 					reg:       make(chan *sessionJoin, 32),
 					unreg:     make(chan *sessionLeave, 32),

--- a/server/topic.go
+++ b/server/topic.go
@@ -90,7 +90,7 @@ type Topic struct {
 
 	// Sessions attached to this topic. The UID kept here may not match Session.uid if session is
 	// subscribed on behalf of another user.
-	sessions map[*Session]perSessionData
+	sessions map[*Session]*perSessionData
 
 	// Inbound {data} and {pres} messages from sessions or other topics, already converted to SCM. Buffered = 256
 	broadcast chan *ServerComMessage
@@ -3264,12 +3264,12 @@ func (t *Topic) addSession(sess *Session, asUid types.Uid, isChanSub bool) {
 
 	if s.isMultiplex() {
 		if sess.background {
-			t.sessions[s] = perSessionData{}
+			t.sessions[s] = &perSessionData{}
 		} else {
-			t.sessions[s] = perSessionData{muids: []types.Uid{asUid}}
+			t.sessions[s] = &perSessionData{muids: []types.Uid{asUid}}
 		}
 	} else {
-		t.sessions[s] = perSessionData{uid: asUid, isChanSub: isChanSub}
+		t.sessions[s] = &perSessionData{uid: asUid, isChanSub: isChanSub}
 	}
 }
 
@@ -3292,7 +3292,7 @@ func (t *Topic) remSession(sess *Session, asUid types.Uid) (*perSessionData, boo
 
 	if pssd.uid == asUid || asUid.IsZero() {
 		delete(t.sessions, s)
-		return &pssd, true
+		return pssd, true
 	}
 
 	for i := range pssd.muids {
@@ -3300,7 +3300,7 @@ func (t *Topic) remSession(sess *Session, asUid types.Uid) (*perSessionData, boo
 			pssd.muids[i] = pssd.muids[len(pssd.muids)-1]
 			pssd.muids = pssd.muids[:len(pssd.muids)-1]
 			t.sessions[s] = pssd
-			return &pssd, false
+			return pssd, false
 		}
 	}
 

--- a/server/topic.go
+++ b/server/topic.go
@@ -90,7 +90,7 @@ type Topic struct {
 
 	// Sessions attached to this topic. The UID kept here may not match Session.uid if session is
 	// subscribed on behalf of another user.
-	sessions map[*Session]*perSessionData
+	sessions map[*Session]perSessionData
 
 	// Inbound {data} and {pres} messages from sessions or other topics, already converted to SCM. Buffered = 256
 	broadcast chan *ServerComMessage
@@ -3257,6 +3257,7 @@ func (t *Topic) addSession(sess *Session, asUid types.Uid, isChanSub bool) {
 			// This slice is expected to be relatively short.
 			// Not doing anything fancy here like maps or sorting.
 			pssd.muids = append(pssd.muids, asUid)
+			t.sessions[s] = pssd
 		}
 		// Maybe panic here.
 		return
@@ -3264,12 +3265,12 @@ func (t *Topic) addSession(sess *Session, asUid types.Uid, isChanSub bool) {
 
 	if s.isMultiplex() {
 		if sess.background {
-			t.sessions[s] = &perSessionData{}
+			t.sessions[s] = perSessionData{}
 		} else {
-			t.sessions[s] = &perSessionData{muids: []types.Uid{asUid}}
+			t.sessions[s] = perSessionData{muids: []types.Uid{asUid}}
 		}
 	} else {
-		t.sessions[s] = &perSessionData{uid: asUid, isChanSub: isChanSub}
+		t.sessions[s] = perSessionData{uid: asUid, isChanSub: isChanSub}
 	}
 }
 
@@ -3292,7 +3293,7 @@ func (t *Topic) remSession(sess *Session, asUid types.Uid) (*perSessionData, boo
 
 	if pssd.uid == asUid || asUid.IsZero() {
 		delete(t.sessions, s)
-		return pssd, true
+		return &pssd, true
 	}
 
 	for i := range pssd.muids {
@@ -3300,7 +3301,7 @@ func (t *Topic) remSession(sess *Session, asUid types.Uid) (*perSessionData, boo
 			pssd.muids[i] = pssd.muids[len(pssd.muids)-1]
 			pssd.muids = pssd.muids[:len(pssd.muids)-1]
 			t.sessions[s] = pssd
-			return pssd, false
+			return &pssd, false
 		}
 	}
 

--- a/server/topic_proxy.go
+++ b/server/topic_proxy.go
@@ -128,8 +128,6 @@ func (t *Topic) handleProxyLeaveRequest(leave *sessionLeave, killTimer *time.Tim
 	if leave.pkt == nil {
 		// Explicitly specify the uid because the master multiplex session needs to know which
 		// of its multiple hosted sessions to delete.
-		// Make a copy of the request in order to keep the original request intact
-		// (otherwise, it may break things).
 		pkt = &ClientComMessage{
 			AsUser: asUid.UserId(),
 			Leave:  &MsgClientLeave{},


### PR DESCRIPTION
Master multiplexing sessions host multiple client sessions.
Sending a leave request w/o uid will result in dropping the whole multiplexing session.
Hence, always specify the uid.