### PR TITLE
Run topic proxy sessions' event loops on a thread pool.

### DIFF
--- a/server/cluster.go
+++ b/server/cluster.go
@@ -916,7 +916,7 @@ func clusterInit(configString json.RawMessage, self *string) int {
 		fingerprint:     time.Now().Unix(),
 		nodes:           make(map[string]*ClusterNode),
 		// TODO: make number of workers configurable.
-		proxyEventQueue: concurrency.NewGoRoutinePool(20)}
+		proxyEventQueue: concurrency.NewGoRoutinePool(len(config.Nodes) * 5)}
 
 	var nodeNames []string
 	for _, host := range config.Nodes {

--- a/server/concurrency/goroutinepool.go
+++ b/server/concurrency/goroutinepool.go
@@ -4,34 +4,31 @@
  *    A very basic and naive implementation of thread pool.
  *
  *****************************************************************************/
-package main
+package concurrency
 
 // Task represents a work task to be run on the specified thread pool.
-type Task struct {
-	// Closure to execute.
-	work func()
-}
+type Task func()
 
-type ThreadPool struct {
+type GoRoutinePool struct {
 	// Work queue.
-	work chan *Task
+	work chan Task
 	// Counter to control the number of already allocated/running goroutines.
 	sem chan struct{}
 	// Exit knob.
 	stop chan struct{}
 }
 
-// NewThreadPool allocates a new thread pool with `numWorkers` goroutines.
-func NewThreadPool(numWorkers int) *ThreadPool {
-	return &ThreadPool{
-		work: make(chan *Task),
+// NewGoRoutinePool allocates a new thread pool with `numWorkers` goroutines.
+func NewGoRoutinePool(numWorkers int) *GoRoutinePool {
+	return &GoRoutinePool{
+		work: make(chan Task),
 		sem:  make(chan struct{}, numWorkers),
 		stop: make(chan struct{}, numWorkers),
 	}
 }
 
-// Schedule enqueus a closure to run on the ThreadPool's goroutines.
-func (p *ThreadPool) Schedule(task *Task) {
+// Schedule enqueus a closure to run on the GoRoutinePool's goroutines.
+func (p *GoRoutinePool) Schedule(task Task) {
 	select {
 	case p.work <- task:
 	case p.sem <- struct{}{}:
@@ -40,7 +37,7 @@ func (p *ThreadPool) Schedule(task *Task) {
 }
 
 // Stop sends a stop signal to all running goroutines.
-func (p *ThreadPool) Stop() {
+func (p *GoRoutinePool) Stop() {
 	numWorkers := cap(p.sem)
 	for i := 0; i < numWorkers; i++ {
 		p.stop <- struct{}{}
@@ -48,10 +45,10 @@ func (p *ThreadPool) Stop() {
 }
 
 // Thread pool worker goroutine.
-func (p *ThreadPool) worker(task *Task) {
+func (p *GoRoutinePool) worker(task Task) {
 	defer func() { <-p.sem }()
 	for {
-		task.work()
+		task()
 		select {
 		case task = <-p.work:
 		case <-p.stop:

--- a/server/session.go
+++ b/server/session.go
@@ -83,7 +83,8 @@ type Session struct {
 	clnode *ClusterNode
 
 	// Reference to multiplexing session. Set only for proxy sessions.
-	multi *Session
+	multi        *Session
+	proxiedTopic string
 
 	// IP address of the client. For long polling this is the IP of the last poll.
 	remoteAddr string
@@ -251,13 +252,22 @@ func (s *Session) isCluster() bool {
 	return s.isProxy() || s.isMultiplex()
 }
 
+func (s *Session) scheduleClusterWriteLoop() {
+	globals.cluster.proxyEventQueue.Schedule(
+		&Task{work: func() { s.clusterWriteLoop(s.proxiedTopic) }})
+}
+
 // queueOut attempts to send a ServerComMessage to a session write loop; if the send buffer is full,
 // timeout is `sendTimeout`.
 func (s *Session) queueOut(msg *ServerComMessage) bool {
 	if s.multi != nil {
 		// In case of a cluster we need to pass a copy of the actual session.
 		msg.sess = s
-		return s.multi.queueOut(msg)
+		if s.multi.queueOut(msg) {
+			s.multi.scheduleClusterWriteLoop()
+			return true
+		}
+		return false
 	}
 
 	// Record latency only on {ctrl} messages and end-user sessions.
@@ -283,6 +293,9 @@ func (s *Session) queueOut(msg *ServerComMessage) bool {
 		log.Println("s.queueOut: timeout", s.sid)
 		return false
 	}
+	if s.isMultiplex() {
+		s.scheduleClusterWriteLoop()
+	}
 	return true
 }
 
@@ -299,7 +312,29 @@ func (s *Session) queueOutBytes(data []byte) bool {
 		log.Println("s.queueOutBytes: timeout", s.sid)
 		return false
 	}
+	if s.isMultiplex() {
+		s.scheduleClusterWriteLoop()
+	}
 	return true
+}
+
+func (s *Session) maybeScheduleClusterWriteLoop() {
+	if s.multi != nil {
+		s.multi.scheduleClusterWriteLoop()
+	}
+	if s.isMultiplex() {
+		s.scheduleClusterWriteLoop()
+	}
+}
+
+func (s *Session) detachSession(fromTopic string) {
+	s.detach <- fromTopic
+	s.maybeScheduleClusterWriteLoop()
+}
+
+func (s *Session) stopSession(data interface{}) {
+	s.stop <- data
+	s.maybeScheduleClusterWriteLoop()
 }
 
 // cleanUp is called when the session is terminated to perform resource cleanup.
@@ -315,7 +350,7 @@ func (s *Session) cleanUp(expired bool) {
 	s.bkgTimer.Stop()
 	s.unsubAll()
 	// Stop the write loop.
-	s.stop <- nil
+	s.stopSession(nil)
 }
 
 // Message received, convert bytes to ClientComMessage and dispatch

--- a/server/session.go
+++ b/server/session.go
@@ -254,7 +254,7 @@ func (s *Session) isCluster() bool {
 
 func (s *Session) scheduleClusterWriteLoop() {
 	globals.cluster.proxyEventQueue.Schedule(
-		&Task{work: func() { s.clusterWriteLoop(s.proxiedTopic) }})
+		func() { s.clusterWriteLoop(s.proxiedTopic) })
 }
 
 // queueOut attempts to send a ServerComMessage to a session write loop; if the send buffer is full,

--- a/server/sessionstore.go
+++ b/server/sessionstore.go
@@ -159,7 +159,7 @@ func (ss *SessionStore) Shutdown() {
 	for _, s := range ss.sessCache {
 		if !s.isMultiplex() {
 			_, data := s.serialize(shutdown)
-			s.stop <- data
+			s.stopSession(data)
 		}
 	}
 
@@ -179,7 +179,7 @@ func (ss *SessionStore) EvictUser(uid types.Uid, skipSid string) {
 	for _, s := range ss.sessCache {
 		if s.uid == uid && !s.isMultiplex() && s.sid != skipSid {
 			_, data := s.serialize(evicted)
-			s.stop <- data
+			s.stopSession(data)
 			delete(ss.sessCache, s.sid)
 			if s.proto == LPOLL {
 				ss.lru.Remove(s.lpTracker)
@@ -202,7 +202,7 @@ func (ss *SessionStore) NodeRestarted(nodeName string, fingerprint int64) {
 			continue
 		}
 		if s.clnode.fingerprint != fingerprint {
-			s.stop <- nil
+			s.stopSession(nil)
 			delete(ss.sessCache, s.sid)
 		}
 	}

--- a/server/threadpool.go
+++ b/server/threadpool.go
@@ -1,0 +1,61 @@
+/******************************************************************************
+ *
+ *  Description :
+ *    A very basic and naive implementation of thread pool.
+ *
+ *****************************************************************************/
+package main
+
+// Task represents a work task to be run on the specified thread pool.
+type Task struct {
+	// Closure to execute.
+	work func()
+}
+
+type ThreadPool struct {
+	// Work queue.
+	work chan *Task
+	// Counter to control the number of already allocated/running goroutines.
+	sem chan struct{}
+	// Exit knob.
+	stop chan struct{}
+}
+
+// NewThreadPool allocates a new thread pool with `numWorkers` goroutines.
+func NewThreadPool(numWorkers int) *ThreadPool {
+	return &ThreadPool{
+		work: make(chan *Task),
+		sem:  make(chan struct{}, numWorkers),
+		stop: make(chan struct{}, numWorkers),
+	}
+}
+
+// Schedule enqueus a closure to run on the ThreadPool's goroutines.
+func (p *ThreadPool) Schedule(task *Task) {
+	select {
+	case p.work <- task:
+	case p.sem <- struct{}{}:
+		go p.worker(task)
+	}
+}
+
+// Stop sends a stop signal to all running goroutines.
+func (p *ThreadPool) Stop() {
+	numWorkers := cap(p.sem)
+	for i := 0; i < numWorkers; i++ {
+		p.stop <- struct{}{}
+	}
+}
+
+// Thread pool worker goroutine.
+func (p *ThreadPool) worker(task *Task) {
+	defer func() { <-p.sem }()
+	for {
+		task.work()
+		select {
+		case task = <-p.work:
+		case <-p.stop:
+			return
+		}
+	}
+}

--- a/server/topic.go
+++ b/server/topic.go
@@ -465,7 +465,7 @@ func (t *Topic) runLocal(hub *Hub) {
 
 			// Tell sessions to remove the topic
 			for s := range t.sessions {
-				s.detach <- t.name
+				s.detachSession(t.name)
 			}
 
 			usersRegisterTopic(t, false)
@@ -2937,7 +2937,7 @@ func (t *Topic) evictUser(uid types.Uid, unsub bool, skip string) {
 	for s := range t.sessions {
 		if pssd, removed := t.remSession(s, uid); pssd != nil {
 			if removed {
-				s.detach <- t.name
+				s.detachSession(t.name)
 			}
 			if s.sid != skip {
 				s.queueOut(msg)

--- a/server/topic_proxy.go
+++ b/server/topic_proxy.go
@@ -37,7 +37,7 @@ func (t *Topic) runProxy(hub *Hub) {
 		case leave := <-t.unreg:
 			if !t.handleProxyLeaveRequest(leave, killTimer) {
 				log.Println("Failed to update proxy topic state for leave request", leave.sess.sid)
-      }
+			}
 			if leave.pkt != nil && leave.sess.inflightReqs != nil {
 				// If it's a client initiated request.
 				leave.sess.inflightReqs.Done()
@@ -82,7 +82,7 @@ func (t *Topic) runProxy(hub *Hub) {
 		case sd := <-t.exit:
 			// Tell sessions to remove the topic
 			for s := range t.sessions {
-				s.detach <- t.name
+				s.detachSession(t.name)
 			}
 
 			if err := globals.cluster.topicProxyGone(t.name); err != nil {
@@ -169,7 +169,7 @@ func (t *Topic) proxyMasterResponse(msg *ClusterResp, killTimer *time.Timer) {
 	} else {
 		sess := globals.sessionStore.Get(msg.OrigSid)
 		if sess == nil {
-			log.Println("topic_proxy: session not found; already terminated?")
+			log.Println("topic_proxy: session not found; already terminated?", msg.OrigSid)
 		}
 		switch msg.OrigReqType {
 		case ProxyReqJoin:
@@ -233,7 +233,7 @@ func (t *Topic) proxyCtrlBroadcast(msg *ServerComMessage) {
 		for sess := range t.sessions {
 			// Proxy topic may only have ordinary sessions. No multiplexing or proxy sessions here.
 			if _, removed := t.remSession(sess, msg.uid); removed {
-				sess.detach <- t.name
+				sess.detachSession(t.name)
 				if sess.sid != msg.SkipSid {
 					sess.queueOut(msg)
 				}

--- a/server/user.go
+++ b/server/user.go
@@ -633,7 +633,7 @@ func replyDelUser(s *Session, msg *ClientComMessage) {
 		// Evict the current session if it belongs to the deleted user.
 		// No need to send it to multiplexing session: remote node will be notified separately.
 		_, data := s.serialize(NoErrEvicted("", "", msg.Timestamp))
-		s.stop <- data
+		s.stopSession(data)
 	}
 }
 


### PR DESCRIPTION
This helps to limit the resources necessary to run a separate goroutine for every multiplexing session's write event loop.