### PR TITLE
[tn-cli]: make 'del user' not require an explicit user id spec.

### DIFF
--- a/server/sanity-test.sh
+++ b/server/sanity-test.sh
@@ -71,9 +71,12 @@ send-requests() {
   local port=$1
   local id=$2
   local outfile=$(mktemp /tmp/tinode-${id}.txt)
-  python3 ../tn-cli/tn-cli.py --host=localhost:${port} --no-login < ../tn-cli/sample-script.txt > $outfile || fail "Test script failed (instance port ${port})"
+  pushd .
+  cd ../tn-cli
+  python3 tn-cli.py --host=localhost:${port} --no-login < sample-script.txt > $outfile || fail "Test script failed (instance port ${port})"
+  popd
   num_positive_responses=`grep -c '<= 20[0-9]' $outfile`
-  if [ $num_positive_responses -ne 10 ]; then fail "Instance ${port}: unexpected number of 20* responses."; fi
+  if [ $num_positive_responses -ne 10 ]; then fail "Instance ${port}: unexpected number of 20* responses: ${num_positive_responses}. Log file ${outfile}"; fi
   rm $outfile
 }
 

--- a/tn-cli/tn-cli.py
+++ b/tn-cli/tn-cli.py
@@ -514,9 +514,6 @@ def delMsg(id, cmd, ignored):
         if cmd.topic:
             stdoutln("Unexpected '--topic' parameter")
             return None
-        if not cmd.user:
-            stdoutln("Must specify user to delete")
-            return None
         enum_what = pb.ClientDel.USER
 
     elif cmd.what == 'cred':


### PR DESCRIPTION
The server attempts to delete the user that owns the session if the user id isn't specified in the request.