### PR TITLE
Roll back to using goroutine pool from gorountine per master topic.

### DIFF
--- a/server/session.go
+++ b/server/session.go
@@ -84,7 +84,8 @@ type Session struct {
 	clnode *ClusterNode
 
 	// Reference to multiplexing session. Set only for proxy sessions.
-	multi *Session
+	multi        *Session
+	proxiedTopic string
 
 	// IP address of the client. For long polling this is the IP of the last poll.
 	remoteAddr string
@@ -259,6 +260,13 @@ func (s *Session) isCluster() bool {
 	return s.isProxy() || s.isMultiplex()
 }
 
+func (s *Session) scheduleClusterWriteLoop() {
+	if globals.cluster != nil && globals.cluster.proxyEventQueue != nil {
+		globals.cluster.proxyEventQueue.Schedule(
+			func() { s.clusterWriteLoop(s.proxiedTopic) })
+	}
+}
+
 // queueOut attempts to send a ServerComMessage to a session write loop; if the send buffer is full,
 // timeout is `sendTimeout`.
 func (s *Session) queueOut(msg *ServerComMessage) bool {
@@ -272,7 +280,11 @@ func (s *Session) queueOut(msg *ServerComMessage) bool {
 	if s.multi != nil {
 		// In case of a cluster we need to pass a copy of the actual session.
 		msg.sess = s
-		return s.multi.queueOut(msg)
+		if s.multi.queueOut(msg) {
+			s.multi.scheduleClusterWriteLoop()
+			return true
+		}
+		return false
 	}
 
 	// Record latency only on {ctrl} messages and end-user sessions.
@@ -299,6 +311,9 @@ func (s *Session) queueOut(msg *ServerComMessage) bool {
 		logs.Err.Println("s.queueOut: session's send queue full", s.sid)
 		return false
 	}
+	if s.isMultiplex() {
+		s.scheduleClusterWriteLoop()
+	}
 	return true
 }
 
@@ -315,17 +330,31 @@ func (s *Session) queueOutBytes(data []byte) bool {
 		logs.Err.Println("s.queueOutBytes: session's send queue full", s.sid)
 		return false
 	}
+	if s.isMultiplex() {
+		s.scheduleClusterWriteLoop()
+	}
 	return true
+}
+
+func (s *Session) maybeScheduleClusterWriteLoop() {
+	if s.multi != nil {
+		s.multi.scheduleClusterWriteLoop()
+	}
+	if s.isMultiplex() {
+		s.scheduleClusterWriteLoop()
+	}
 }
 
 func (s *Session) detachSession(fromTopic string) {
 	if atomic.LoadInt32(&s.terminating) == 0 {
 		s.detach <- fromTopic
+		s.maybeScheduleClusterWriteLoop()
 	}
 }
 
 func (s *Session) stopSession(data interface{}) {
 	s.stop <- data
+	s.maybeScheduleClusterWriteLoop()
 }
 
 func (sess *Session) purgeChannels() {

--- a/server/session.go
+++ b/server/session.go
@@ -339,6 +339,7 @@ func (s *Session) queueOutBytes(data []byte) bool {
 func (s *Session) maybeScheduleClusterWriteLoop() {
 	if s.multi != nil {
 		s.multi.scheduleClusterWriteLoop()
+		return
 	}
 	if s.isMultiplex() {
 		s.scheduleClusterWriteLoop()

--- a/server/topic.go
+++ b/server/topic.go
@@ -10,14 +10,12 @@ package main
 
 import (
 	"errors"
-	"reflect"
 	"sort"
 	"strings"
 	"sync/atomic"
 	"time"
 
 	"github.com/tinode/chat/server/auth"
-	"github.com/tinode/chat/server/concurrency"
 	"github.com/tinode/chat/server/logs"
 	"github.com/tinode/chat/server/push"
 	"github.com/tinode/chat/server/store"
@@ -48,22 +46,6 @@ type Topic struct {
 	isProxy bool
 	// Name of the master node for this topic if isProxy is true.
 	masterNode string
-	// Topic runs a goroutine (clusterWriteLoop) that reads events from all proxy
-	// multiplexing sessions.
-	// List of proxied sessions.
-	proxiedSessions []*Session
-	// Proxied sessions' channels for the use in the topic's clusterWriteLoop:
-	// i-th session's channels (proxiedSessions[i]) are found at:
-	// proxiedChannels[i * 3 + 1] - send
-	// proxiedChannels[i * 3 + 2] - stop
-	// proxiedChannels[i * 3 + 3] - detach
-	//
-	// proxiedChannels[0] is a special-purpose channel necessary for interrupting
-	// clusterWriteLoop when sessions are added or removed.
-	proxiedChannels []reflect.SelectCase
-	// Guards proxiedSessions and proxiedTopics (not using sync.Mutex here
-	// since we need TryLock functionality).
-	proxiedLock concurrency.SimpleMutex
 
 	// Time when the topic was first created.
 	created time.Time
@@ -3355,77 +3337,6 @@ func (t *Topic) subsCount() int {
 	return len(t.perUser)
 }
 
-// Adds a new multiplex proxied session to the topic's clusterWriteLoop.
-func (t *Topic) addProxiedSession(s *Session) {
-	// Send an interrupt signal to clusterWriteLoop that a new session
-	// is being added and acquire the lock.
-	if len(t.proxiedChannels) > 0 {
-		interruptChan := t.proxiedChannels[0].Chan.Interface().(chan struct{})
-		for !t.proxiedLock.TryLock() {
-			interruptChan <- struct{}{}
-		}
-	} else {
-		if t.proxiedLock == nil {
-			t.proxiedLock = concurrency.NewSimpleMutex()
-		}
-		t.proxiedLock.Lock()
-	}
-	// At this point we are guaranteed to have grabbed t.proxiedLock.
-	t.proxiedSessions = append(t.proxiedSessions, s)
-	if len(t.proxiedSessions) == 1 {
-		t.proxiedChannels = make([]reflect.SelectCase, 1+3)
-		continueChan := make(chan struct{})
-		t.proxiedChannels[0] = reflect.SelectCase{Dir: reflect.SelectRecv, Chan: reflect.ValueOf(continueChan)}
-		t.proxiedChannels[EventSend] = reflect.SelectCase{Dir: reflect.SelectRecv, Chan: reflect.ValueOf(s.send)}
-		t.proxiedChannels[EventStop] = reflect.SelectCase{Dir: reflect.SelectRecv, Chan: reflect.ValueOf(s.stop)}
-		t.proxiedChannels[EventDetach] = reflect.SelectCase{Dir: reflect.SelectRecv, Chan: reflect.ValueOf(s.detach)}
-		go t.clusterWriteLoop()
-	} else {
-		t.proxiedChannels = append(t.proxiedChannels, reflect.SelectCase{Dir: reflect.SelectRecv, Chan: reflect.ValueOf(s.send)})
-		t.proxiedChannels = append(t.proxiedChannels, reflect.SelectCase{Dir: reflect.SelectRecv, Chan: reflect.ValueOf(s.stop)})
-		t.proxiedChannels = append(t.proxiedChannels, reflect.SelectCase{Dir: reflect.SelectRecv, Chan: reflect.ValueOf(s.detach)})
-	}
-	t.proxiedLock.Unlock()
-}
-
-// Removes a multiplex proxied session from the topic's clusterWriteLoop.
-func (t *Topic) remProxiedSession(sess *Session) bool {
-	interruptChan := t.proxiedChannels[0].Chan.Interface().(chan struct{})
-	for !t.proxiedLock.TryLock() {
-		interruptChan <- struct{}{}
-	}
-	defer func() { t.proxiedLock.Unlock() }()
-	for i, s := range t.proxiedSessions {
-		if sess == s {
-			if len(t.proxiedSessions) == 1 {
-				t.proxiedSessions = nil
-				t.proxiedChannels = nil
-			} else {
-				n := len(t.proxiedSessions)
-				// Move last session into position i.
-				t.proxiedSessions[i] = t.proxiedSessions[n-1]
-				t.proxiedSessions[n-1] = nil
-				t.proxiedSessions = t.proxiedSessions[:n-1]
-
-				// Move channels into position i.
-				for j := 0; j < 3; j++ {
-					to := i*3 + 1 + j
-					from := (n-1)*3 + 1 + j
-					t.proxiedChannels[to] = t.proxiedChannels[from]
-				}
-				numChans := len(t.proxiedChannels) - 3
-				t.proxiedChannels = t.proxiedChannels[:numChans]
-				if len(t.proxiedSessions)*3+1 != len(t.proxiedChannels) {
-					logs.Err.Panicf("topic[%s]: #proxied sessions (%d) vs #proxied channels mismatch (%d)",
-						t.name, len(t.proxiedSessions), len(t.proxiedChannels))
-				}
-			}
-			return true
-		}
-	}
-	return false
-}
-
 // Add session record. 'user' may be different from sess.uid.
 func (t *Topic) addSession(sess *Session, asUid types.Uid, isChanSub bool) {
 	s := sess
@@ -3451,7 +3362,6 @@ func (t *Topic) addSession(sess *Session, asUid types.Uid, isChanSub bool) {
 		} else {
 			t.sessions[s] = perSessionData{muids: []types.Uid{asUid}}
 		}
-		t.addProxiedSession(s)
 	} else {
 		t.sessions[s] = perSessionData{uid: asUid, isChanSub: isChanSub}
 	}
@@ -3476,9 +3386,6 @@ func (t *Topic) remSession(sess *Session, asUid types.Uid) (*perSessionData, boo
 
 	if pssd.uid == asUid || asUid.IsZero() {
 		delete(t.sessions, s)
-		if s.isMultiplex() && !t.remProxiedSession(s) {
-			logs.Err.Printf("topic[%s]: multiplex session %s not removed from the event loop", t.name, s.sid)
-		}
 		return &pssd, true
 	}
 
@@ -3489,9 +3396,6 @@ func (t *Topic) remSession(sess *Session, asUid types.Uid) (*perSessionData, boo
 			t.sessions[s] = pssd
 			if len(pssd.muids) == 0 {
 				delete(t.sessions, s)
-				if s.isMultiplex() && !t.remProxiedSession(s) {
-					logs.Err.Printf("topic[%s]: multiplex session %s not removed from the event loop: no more attached uids", t.name, s.sid)
-				}
 				return &pssd, true
 			} else {
 				return &pssd, false


### PR DESCRIPTION
Context: handling of cluster events.
Currently, we spawn a goroutine per master topic and multiplex proxy sessions over this goroutine using `reflect.Select`. 

This logic of using `reflect.Select` turns out to be quite pricey
in terms of both cpu and memory when the number of nodes goes up (the profile was obtained from a 5-node cluster under load).

```(pprof) top 20
Showing nodes accounting for 41800ms, 69.91% of 59790ms total
Dropped 360 nodes (cum <= 298.95ms)
Showing top 20 nodes out of 96
      flat  flat%   sum%        cum   cum%
    5300ms  8.86%  8.86%     7720ms 12.91%  runtime.scanobject
    4250ms  7.11% 15.97%    18370ms 30.72%  runtime.mallocgc
    3980ms  6.66% 22.63%     5360ms  8.96%  runtime.findObject
    3860ms  6.46% 29.09%     4690ms  7.84%  runtime.heapBitsSetType
    3710ms  6.21% 35.29%    13760ms 23.01%  runtime.selectgo
    2580ms  4.32% 39.61%     2580ms  4.32%  runtime.unlock
    2560ms  4.28% 43.89%     7800ms 13.05%  runtime.gcWriteBarrier
    2430ms  4.06% 47.95%     2440ms  4.08%  runtime.lock
    2070ms  3.46% 51.41%    37530ms 62.77%  reflect.Select
    1620ms  2.71% 54.12%     1700ms  2.84%  runtime.nanotime
    1560ms  2.61% 56.73%     1560ms  2.61%  runtime.nextFreeFast
    1480ms  2.48% 59.21%     1480ms  2.48%  runtime.memclrNoHeapPointers
    1220ms  2.04% 61.25%     5720ms  9.57%  runtime.wbBufFlush1
    1070ms  1.79% 63.04%     1370ms  2.29%  runtime.spanOf (partial-inline)
     980ms  1.64% 64.68%    23660ms 39.57%  reflect.rselect
     710ms  1.19% 65.86%      890ms  1.49%  runtime.heapBitsForAddr (inline)
     610ms  1.02% 66.88%      610ms  1.02%  runtime.acquirem (partial-inline)
     610ms  1.02% 67.90%     4250ms  7.11%  runtime.chansend
     600ms  1.00% 68.91%      790ms  1.32%  runtime.(*waitq).dequeue
     600ms  1.00% 69.91%      600ms  1.00%  runtime.casgstatus
```
