### PR TITLE
Move some stuff off of Topic.run critical path.

### DIFF
--- a/server/hdl_grpc.go
+++ b/server/hdl_grpc.go
@@ -72,6 +72,19 @@ func (*grpcNodeServer) MessageLoop(stream pbx.Node_MessageLoopServer) error {
 	return nil
 }
 
+func (sess *Session) sendMessageGrpc(msg interface{}) bool {
+	if len(sess.send) > sendQueueLimit {
+		logs.Err.Println("grpc: outbound queue limit exceeded", sess.sid)
+		return false
+	}
+	statsInc("OutgoingMessagesGrpcTotal", 1)
+	if err := grpcWrite(sess, msg); err != nil {
+		logs.Err.Println("grpc: write", sess.sid, err)
+		return false
+	}
+	return true
+}
+
 func (sess *Session) writeGrpcLoop() {
 
 	defer func() {
@@ -85,14 +98,23 @@ func (sess *Session) writeGrpcLoop() {
 				// channel closed
 				return
 			}
-			if len(sess.send) > sendQueueLimit {
-				logs.Err.Println("grpc: outbound queue limit exceeded", sess.sid)
-				return
-			}
-			statsInc("OutgoingMessagesGrpcTotal", 1)
-			if err := grpcWrite(sess, msg); err != nil {
-				logs.Err.Println("grpc: write", sess.sid, err)
-				return
+			switch v := msg.(type) {
+			case []*ServerComMessage: // batch of unserialized messages
+				for _, msg := range v {
+					w := sess.serializeAndUpdateStats(msg)
+					if !sess.sendMessageGrpc(w) {
+						return
+					}
+				}
+			case *ServerComMessage: // single unserialized message
+				w := sess.serializeAndUpdateStats(v)
+				if !sess.sendMessageGrpc(w) {
+					return
+				}
+			default: // serialized message
+				if !sess.sendMessageGrpc(v) {
+					return
+				}
 			}
 
 		case <-sess.bkgTimer.C:

--- a/server/session.go
+++ b/server/session.go
@@ -1332,10 +1332,9 @@ func (s *Session) serialize(msg *ServerComMessage) (int, interface{}) {
 		return -1, msg
 	}
 
-	if s.proto == MULTIPLEX {
-		// No need to serialize the message to bytes within the cluster,
-		// but we have to create a copy because the original msg can be mutated.
-		return -1, msg.copy()
+	if s.isMultiplex() {
+		// No need to serialize the message to bytes within the cluster.
+		return -1, msg
 	}
 
 	out, _ := json.Marshal(msg)

--- a/server/topic.go
+++ b/server/topic.go
@@ -1048,7 +1048,8 @@ func (t *Topic) handleBroadcast(msg *ServerComMessage) {
 			msg.Data.From = ""
 		}
 		// Send message to session.
-		if !sess.queueOut(msg) {
+		// Make a copy of msg since messages sent to sessions differ.
+		if !sess.queueOut(msg.copy()) {
 			logs.Warn.Printf("topic[%s]: connection stuck, detaching - %s", t.name, sess.sid)
 			dropSessions = append(dropSessions, sess)
 		}


### PR DESCRIPTION
Less blocking on the Topic.run critical path.
Move message serialization to the Session's writeLoop.
Allow batch sending of messages to the Session in order
to avoid sending messages to the Sessions' writeLoop
one by one (and thus incur synchronization costs).