### PR TITLE
Sending rich pushes and passing info-kp through me topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Words 'chat' and 'instant messaging' in Chinese, Russian, Persian and a few othe
 * чат мессенджер
 * インスタントメッセージ
 * 인스턴트 메신저
-* پیام‌رسانی فوری گپ
+* پیام رسان فوری
 * تراسل فوري
 * Nhắn tin tức thời
 * anlık mesajlaşma sohbet

--- a/server/drafty/drafty.go
+++ b/server/drafty/drafty.go
@@ -2,6 +2,7 @@
 package drafty
 
 import (
+	"encoding/json"
 	"errors"
 	"sort"
 	"strings"
@@ -115,7 +116,7 @@ var tags = map[string]spanfmt{
 
 // Preview shortens Drafty to the specified length (in runes) and removes large content from entities making them
 // suitable for a one-line preview, for example for showing in push notifications.
-func Preview(content interface{}, length int) (interface{}, error) {
+func Preview(content interface{}, length int) (string, error) {
 	if content == nil {
 		return "", nil
 	}
@@ -210,7 +211,9 @@ func Preview(content interface{}, length int) (interface{}, error) {
 		}
 	}
 
-	return preview, nil
+	data, err := json.Marshal(preview)
+
+	return string(data), err
 }
 
 var lightData = []string{"mime", "name", "width", "height", "size"}

--- a/server/drafty/drafty_test.go
+++ b/server/drafty/drafty_test.go
@@ -2,13 +2,12 @@ package drafty
 
 import (
 	"encoding/json"
-	"reflect"
 	"testing"
 )
 
 var validInputs = []string{
 	`{
-		"ent":[{"data":{"mime":"image/jpeg","name":"hello.jpg","val":"<38992, bytes: ...>"},"tp":"EX"}],
+		"ent":[{"data":{"mime":"image/jpeg","name":"hello.jpg","val":"<38992, bytes: ...>","width":100, "height":80},"tp":"EX"}],
 		"fmt":[{"at":-1, "key":0}]
 	}`,
 	`{
@@ -96,50 +95,14 @@ func TestToPlainText(t *testing.T) {
 }
 
 func TestPreview(t *testing.T) {
-	expect := []map[string]interface{}{
-		map[string]interface{}{
-			"fmt": []map[string]interface{}{map[string]interface{}{"at": -1, "key": 0}},
-			"ent": []map[string]interface{}{map[string]interface{}{
-				"tp":   "EX",
-				"data": map[string]interface{}{"mime": "image/jpeg", "name": "hello.jpg"}},
-			},
-		},
-		map[string]interface{}{
-			"txt": "https://api.tin",
-			"fmt": []map[string]interface{}{map[string]interface{}{"len": 22, "key": 0}},
-			"ent": []map[string]interface{}{map[string]interface{}{"tp": "LN"}},
-		},
-		map[string]interface{}{
-			"txt": "https://api.tin",
-			"fmt": []map[string]interface{}{map[string]interface{}{"len": 22, "key": 0}},
-			"ent": []map[string]interface{}{map[string]interface{}{"tp": "LN"}},
-		},
-		map[string]interface{}{
-			"txt": " ",
-			"fmt": []map[string]interface{}{map[string]interface{}{"len": 1, "key": 0}},
-			"ent": []map[string]interface{}{map[string]interface{}{
-				"tp": "IM",
-				"data": map[string]interface{}{
-					"width":  638.0,
-					"height": 213.0,
-					"mime":   "image/jpeg",
-					"name":   "roses.jpg",
-				},
-			}},
-		},
-		map[string]interface{}{
-			"txt": "This text is fo",
-			"fmt": []map[string]interface{}{
-				map[string]interface{}{"at": 5, "len": 4, "tp": "ST"},
-				map[string]interface{}{"at": 13, "len": 9, "tp": "EM"},
-			},
-		},
-		map[string]interface{}{
-			"txt": "мультибайтовый ",
-			"fmt": []map[string]interface{}{map[string]interface{}{"tp": "ST", "len": 14}},
-		},
+	expect := []string{
+		`{"ent":[{"data":{"height":80,"mime":"image/jpeg","name":"hello.jpg","width":100},"tp":"EX"}],"fmt":[{"at":-1,"key":0}]}`,
+		`{"ent":[{"tp":"LN"}],"fmt":[{"key":0,"len":22}],"txt":"https://api.tin"}`,
+		`{"ent":[{"tp":"LN"}],"fmt":[{"key":0,"len":22}],"txt":"https://api.tin"}`,
+		`{"ent":[{"data":{"height":213,"mime":"image/jpeg","name":"roses.jpg","width":638},"tp":"IM"}],"fmt":[{"key":0,"len":1}],"txt":" "}`,
+		`{"fmt":[{"at":5,"len":4,"tp":"ST"},{"at":13,"len":9,"tp":"EM"}],"txt":"This text is fo"}`,
+		`{"fmt":[{"len":14,"tp":"ST"}],"txt":"мультибайтовый "}`,
 	}
-
 	for i := range validInputs {
 		var val interface{}
 		json.Unmarshal([]byte(validInputs[i]), &val)
@@ -148,7 +111,7 @@ func TestPreview(t *testing.T) {
 			t.Error(err)
 		}
 
-		if !reflect.DeepEqual(res, expect[i]) {
+		if res != expect[i] {
 			t.Errorf("%d output '%s' does not match '%s'", i, res, expect[i])
 		}
 	}

--- a/server/pres.go
+++ b/server/pres.go
@@ -413,23 +413,9 @@ func (t *Topic) presSubsOffline(what string, params *presParams,
 	}
 }
 
-// Publish {info what=read|recv} to topic subscribers's sessions currently offline in the topic, on subscriber's 'me'.
-// Group and P2P to all with 'R' & 'P' permissions.
-func (t *Topic) infoSubsOffline(from types.Uid, recv, read int, skipSid string) {
-
-	var seq int
-	var what string
-
-	if recv > 0 {
-		what = "recv"
-		seq = recv
-	} else if read > 0 {
-		what = "read"
-		seq = read
-	} else {
-		return
-	}
-
+// Publish {info what=read|recv|kp} to topic subscribers's sessions currently offline in the topic, on subscriber's 'me'.
+// Group and P2P.
+func (t *Topic) infoSubsOffline(from types.Uid, what string, seq int, skipSid string) {
 	user := from.UserId()
 
 	for uid, pud := range t.perUser {
@@ -542,9 +528,10 @@ func presSingleUserOfflineOffline(uid types.Uid, original, what string, params *
 		RcptTo: uid.UserId(), SkipSid: skipSid}
 }
 
-// Let other sessions of a given user know what messages are now received/read
+// Let other sessions of a given user know what messages are now received/read.
+// If both 'read' and 'recv' != 0 then 'read' takes precedence over 'recv'.
 // Cases U
-func (t *Topic) presPubMessageCount(uid types.Uid, mode types.AccessMode, recv, read int, skip string) {
+func (t *Topic) presPubMessageCount(uid types.Uid, mode types.AccessMode, read, recv int, skip string) {
 	var what string
 	var seq int
 	if read > 0 {

--- a/server/push/fcm/push_fcm.go
+++ b/server/push/fcm/push_fcm.go
@@ -32,10 +32,6 @@ const (
 
 	// The number of sub/unsub requests sent in one batch. FCM constant.
 	subBatchSize = 1000
-
-	// Maximum length of a text message in runes. The message is clipped if length is exceeded.
-	// TODO: implement intelligent clipping of Drafty messages.
-	maxMessageLength = 80
 )
 
 // Handler represents the push handler; implements push.PushHandler interface.

--- a/server/push/push.go
+++ b/server/push/push.go
@@ -17,6 +17,9 @@ const (
 	ActSub = "sub"
 )
 
+// Maximum length of push payload in multibyte characters.
+const MaxPayloadLength = 128
+
 // Recipient is a user targeted by the push.
 type Recipient struct {
 	// Count of user's connections that were live when the packet was dispatched from the server


### PR DESCRIPTION
Two unrelated changes:

1. Actually sending rich push notifications using json-encoded drafty message previews (generation of them was reviewed earlier) in addition to plain text pushes.

2. Add `kp` to https://github.com/tinode/chat/pull/595. See discussion at https://github.com/tinode/chat/issues/599