### PR TITLE
Fix iOS push notifications.

### DIFF
--- a/server/push/fcm/payload.go
+++ b/server/push/fcm/payload.go
@@ -262,6 +262,7 @@ func PrepareNotifications(rcpt *push.Receipt, config *AndroidConfig) []MessageDa
 		}
 	}
 
+	// TODO(aforge): introduce iOS push configuration (similar to Android).
 	titleIOS := "New message"
 	bodyIOS := data["content"]
 	apnsNotification := func(msg *fcm.Message) {

--- a/server/push/fcm/payload.go
+++ b/server/push/fcm/payload.go
@@ -262,6 +262,8 @@ func PrepareNotifications(rcpt *push.Receipt, config *AndroidConfig) []MessageDa
 		}
 	}
 
+	titleIOS := "New message"
+	bodyIOS := data["content"]
 	apnsNotification := func(msg *fcm.Message) {
 		msg.APNS = &fcm.APNSConfig{
 			Payload: &fcm.APNSPayload{
@@ -272,8 +274,8 @@ func PrepareNotifications(rcpt *push.Receipt, config *AndroidConfig) []MessageDa
 					// Need to duplicate these in APNS.Payload.Aps.Alert so
 					// iOS may call NotificationServiceExtension (if present).
 					Alert: &fcm.ApsAlert{
-						Title: title,
-						Body:  body,
+						Title: titleIOS,
+						Body:  bodyIOS,
 					},
 				},
 			},


### PR DESCRIPTION
We must fill in aps.alert struct in order for alerts
to show up on the device.