### PR TITLE
Mysql: limit the number of db connections.

### DIFF
--- a/server/db/adapter.go
+++ b/server/db/adapter.go
@@ -34,6 +34,8 @@ type Adapter interface {
 	UpgradeDb() error
 	// Version returns adapter version
 	Version() int
+	// DB connection stats object.
+	Stats() interface{}
 
 	// User management
 

--- a/server/db/mongodb/adapter.go
+++ b/server/db/mongodb/adapter.go
@@ -231,6 +231,11 @@ func (a *adapter) Version() int {
 	return adpVersion
 }
 
+// DB connection stats object.
+func (a *adapter) Stats() interface{} {
+	return nil
+}
+
 // GetName returns the name of the adapter
 func (a *adapter) GetName() string {
 	return adapterName
@@ -1492,7 +1497,7 @@ func (a *adapter) OwnTopics(uid t.Uid) ([]string, error) {
 // ChannelsForUser loads a slice of topic names where the user is a channel reader and notifications (P) are enabled.
 func (a *adapter) ChannelsForUser(uid t.Uid) ([]string, error) {
 	filter := b.M{
-		"user":      user.String(),
+		"user":      uid.String(),
 		"deletedat": b.M{"$exists": false},
 		"topic":     b.M{"$regex": primitive.Regex{Pattern: "^chn"}},
 		"modewant":  b.M{"$bitsAllSet": b.A{t.ModePres}},

--- a/server/db/mysql/adapter.go
+++ b/server/db/mysql/adapter.go
@@ -13,8 +13,6 @@ import (
 	"time"
 
 	ms "github.com/go-sql-driver/mysql"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/jmoiron/sqlx"
 	"github.com/tinode/chat/server/auth"
 	"github.com/tinode/chat/server/store"
@@ -47,9 +45,9 @@ const (
 )
 
 type configType struct {
-  // DB connection settings.
-  // Please, see https://pkg.go.dev/github.com/go-sql-driver/mysql#Config
-  // for the full list of fields.
+	// DB connection settings.
+	// Please, see https://pkg.go.dev/github.com/go-sql-driver/mysql#Config
+	// for the full list of fields.
 	ms.Config
 	// Deprecated.
 	DSN      string `json:"dsn,omitempty"`
@@ -78,15 +76,12 @@ func (a *adapter) Open(jsonconfig json.RawMessage) error {
 		return errors.New("mysql adapter failed to parse config: " + err.Error())
 	}
 
-	locationCmp := cmp.Comparer(func(x, y time.Location) bool {
-		return x.String() == y.String()
-	})
-	if !cmp.Equal(*defaultCfg, config.Config, locationCmp, cmpopts.IgnoreUnexported(ms.Config{})) {
+	if dsn := config.FormatDSN(); dsn != defaultCfg.FormatDSN() {
 		// MySql config is specified. Use it.
 		a.dbName = config.DBName
-		a.dsn = config.FormatDSN()
+		a.dsn = dsn
 		if config.DSN != "" || config.Database != "" {
-			return errors.New("mysql config: dsn and database fields are deprecated. Please, specify individual connection settings via mysql.Config: https://pkg.go.dev/github.com/go-sql-driver/mysql#Config")
+			return errors.New("mysql config: `dsn` and `database` fields are deprecated. Please, specify individual connection settings via mysql.Config: https://pkg.go.dev/github.com/go-sql-driver/mysql#Config")
 		}
 	} else {
 		// Otherwise, use DSN and Database to configure database connection.

--- a/server/db/rethinkdb/adapter.go
+++ b/server/db/rethinkdb/adapter.go
@@ -212,6 +212,11 @@ func (adapter) Version() int {
 	return adpVersion
 }
 
+// DB connection stats object.
+func (a *adapter) Stats() interface{} {
+	return nil
+}
+
 // GetName returns string that adapter uses to register itself with store.
 func (a *adapter) GetName() string {
 	return adapterName

--- a/server/main.go
+++ b/server/main.go
@@ -364,6 +364,7 @@ func main() {
 		logs.Info.Println("Closed database connection(s)")
 		logs.Info.Println("All done, good bye")
 	}()
+	statsRegisterDbStats()
 
 	// API key signing secret
 	globals.apiKeySalt = config.APIKeySalt

--- a/server/stats.go
+++ b/server/stats.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/tinode/chat/server/logs"
+	"github.com/tinode/chat/server/store"
 )
 
 // A simple implementation of histogram expvar.Var.
@@ -71,6 +72,12 @@ func statsInit(mux *http.ServeMux, path string) {
 	go statsUpdater()
 
 	logs.Info.Printf("stats: variables exposed at '%s'", path)
+}
+
+func statsRegisterDbStats() {
+	if f := store.DbStats(); f != nil {
+		expvar.Publish("DbStats", expvar.Func(f))
+	}
 }
 
 // Register integer variable. Don't check for initialization.

--- a/server/store/store.go
+++ b/server/store/store.go
@@ -206,6 +206,14 @@ func EncodeUid(id int64) types.Uid {
 	return uGen.EncodeInt64(id)
 }
 
+// Returns a callback returning db connection stats object.
+func DbStats() func() interface{} {
+	if !IsOpen() {
+		return nil
+	}
+	return adp.Stats
+}
+
 // UsersObjMapper is a users struct to hold methods for persistence mapping for the User object.
 type UsersObjMapper struct{}
 

--- a/server/tinode.conf
+++ b/server/tinode.conf
@@ -190,7 +190,14 @@
 				// See https://github.com/go-sql-driver/mysql#dsn-data-source-name for syntax.
 				"dsn": "root@tcp(localhost)/tinode?parseTime=true&collation=utf8mb4_unicode_ci",
 				// Name of the main database.
-				"database": "tinode"
+				"database": "tinode",
+				// Maximum number of open connections to the database. Default: 0 (unlimited).
+				// "max_open_conns": 64,
+				// Maximum number of connections in the idle connection pool. If negative or zero,
+				// no idle connections are retained.
+				// "max_idle_conns": 64,
+				// Maximum amount of time a connection may be reused.
+				// "conn_max_lifetime_seconds": 60
 			},
 
 			// RethinkDB configuration. See

--- a/server/tinode.conf
+++ b/server/tinode.conf
@@ -184,20 +184,33 @@
 			// MySQL configuration. See https://godoc.org/github.com/go-sql-driver/mysql#Config
 			// for other possible options.
 			"mysql": {
-				// DSN, passed unchanged to MySQL driver. The 'parseTime=true' is required.
+				// MySQL connection settings.
+				// See https://pkg.go.dev/github.com/go-sql-driver/mysql#Config for more info
+				// and available fields and options.
+				"User": "root",
+				"Net": "tcp",
+				"Addr": "localhost",
+				"DBName": "tinode",
 				// The 'collation=utf8mb4_unicode_ci' is optional but highly recommended for
 				// emoji and certain CJK characters.
-				// See https://github.com/go-sql-driver/mysql#dsn-data-source-name for syntax.
-				"dsn": "root@tcp(localhost)/tinode?parseTime=true&collation=utf8mb4_unicode_ci",
+				"Collation": "utf8mb4_unicode_ci",
+				// Parse time values to time.Time. Required.
+				"ParseTime": true,
+
+				// Deprecated connection settings. Kept for backward compatibility.
+				// DSN, passed unchanged to MySQL driver. See https://github.com/go-sql-driver/mysql#dsn-data-source-name for syntax.
+				// "dsn": "root@tcp(localhost)/tinode?parseTime=true&collation=utf8mb4_unicode_ci",
 				// Name of the main database.
-				"database": "tinode",
+				// "database": "tinode",
+
+				// MySQL connection pool settings.
 				// Maximum number of open connections to the database. Default: 0 (unlimited).
-				// "max_open_conns": 64,
+				"max_open_conns": 64,
 				// Maximum number of connections in the idle connection pool. If negative or zero,
 				// no idle connections are retained.
-				// "max_idle_conns": 64,
+				"max_idle_conns": 64,
 				// Maximum amount of time a connection may be reused.
-				// "conn_max_lifetime_seconds": 60
+				"conn_max_lifetime_seconds": 60
 			},
 
 			// RethinkDB configuration. See


### PR DESCRIPTION
Limiting the number of connections prevents Tinode server from overwhelming
the database. It gives Tinode server a more controlled and stable behavior.
Per http://dsas.blog.klab.org/archives/2018-02/configure-sql-db.html.