### PR TITLE
Fix docker readme environment variables table

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -140,7 +140,6 @@ You can specify the following environment variables when issuing `docker run` co
 | `AWS_SECRET_ACCESS_KEY` | string |  | AWS [Secret Access Key](https://aws.amazon.com/blogs/security/wheres-my-secret-access-key/) when using `s3` media handler |
 | `CLUSTER_SELF` | string |  | Node name if the server is running in a Tinode cluster |
 | `CLUSTER_NUM_PROXY_EVENT_GOROUTINES` | int | 0 | Number of goroutines used for processing topic master to proxy responses |
-
 | `DEBUG_EMAIL_VERIFICATION_CODE` | string |  | Enable dummy email verification code, e.g. `123456`. Disabled by default (empty string). |
 | `EXT_CONFIG` | string |  | Path to external config file to use instead of the built-in one. If this parameter is used all other variables except `RESET_DB`, `FCM_SENDER_ID`, `FCM_VAPID_KEY` are ignored. |
 | `EXT_STATIC_DIR` | string |  | Path to external directory containing static data (e.g. Tinode Webapp files) |

--- a/docker/README.md
+++ b/docker/README.md
@@ -189,6 +189,7 @@ $ docker run -p 6222:6222 -d --name tinode-exporter --network tinode-net \
 ```
 
 Available variables:
+
 | Variable | Type | Default | Function |
 | --- | --- | --- | --- |
 | `SERVE_FOR` | string | `` | Monitoring service: `prometheus` or `influxdb` |


### PR DESCRIPTION
Currently the [table listing the available environment variables in the docker readme](https://github.com/tinode/chat/blob/master/docker/README.md#supported-environment-variables) is not correctly shown. This is caused by an additional newline which breaks the markdown table formatting. This simple PR removes the newline so the table is redered correctly.