### PR TITLE
Clean up deletions in mongodb adapter

### DIFF
--- a/server/db/adapter.go
+++ b/server/db/adapter.go
@@ -118,8 +118,9 @@ type Adapter interface {
 
 	// SubscriptionGet reads a subscription of a user to a topic
 	SubscriptionGet(topic string, user t.Uid) (*t.Subscription, error)
-	// SubsForUser gets a list of topics of interest for a given user. Does NOT load Public value.
-	SubsForUser(user t.Uid, keepDeleted bool, opts *t.QueryOpt) ([]t.Subscription, error)
+	// SubsForUser loads all subscriptions of a given user. Does NOT load Public or Private values,
+	// does not load deleted subscriptions.
+	SubsForUser(user t.Uid) ([]t.Subscription, error)
 	// SubsForTopic gets a list of subscriptions to a given topic.. Does NOT load Public value.
 	SubsForTopic(topic string, keepDeleted bool, opts *t.QueryOpt) ([]t.Subscription, error)
 	// SubsUpdate updates pasrt of a subscription object. Pass nil for fields which don't need to be updated

--- a/server/db/mongodb/adapter.go
+++ b/server/db/mongodb/adapter.go
@@ -1753,7 +1753,7 @@ func (a *adapter) SubsDelete(topic string, user t.Uid) error {
 
 	forUser := user.String()
 
-	if err = mdb.WithSession(a.ctx, sess, func(sc mdb.SessionContext) error {
+	return mdb.WithSession(a.ctx, sess, func(sc mdb.SessionContext) error {
 		if err := a.subsDelete(sc, b.M{"_id": topic + ":" + forUser}, false); err != nil {
 			return err
 		}
@@ -1774,10 +1774,7 @@ func (a *adapter) SubsDelete(topic string, user t.Uid) error {
 		}
 		// Commit changes.
 		return a.maybeCommitTransaction(sc, sess)
-	}); err != nil {
-		return err
-	}
-	return nil
+	})
 }
 
 // Delete/mark deleted subscriptions.

--- a/server/db/mongodb/adapter.go
+++ b/server/db/mongodb/adapter.go
@@ -590,12 +590,11 @@ func (a *adapter) maybeCommitTransaction(ctx context.Context, sess mdb.Session) 
 	return nil
 }
 
-// FIXME: delete user's dellog entries
-// FIXME: delete user's markings of soft-deleted messages
-
-// UserDelete deletes user record
+// UserDelete deletes user record.
 func (a *adapter) UserDelete(uid t.Uid, hard bool) error {
-	topicIds, err := a.db.Collection("topics").Distinct(a.ctx, "_id", b.M{"owner": uid.String()})
+	forUser := uid.String()
+	// Select topics where the user is the owner.
+	topicIds, err := a.db.Collection("topics").Distinct(sc, "_id", b.M{"owner": forUser})
 	if err != nil {
 		return err
 	}
@@ -610,53 +609,77 @@ func (a *adapter) UserDelete(uid t.Uid, hard bool) error {
 	if err = a.maybeStartTransaction(sess); err != nil {
 		return err
 	}
+
 	if err = mdb.WithSession(a.ctx, sess, func(sc mdb.SessionContext) error {
+
 		if hard {
 			// Can't delete user's messages in all topics because we cannot notify topics of such deletion.
 			// Or we have to delete these messages one by one.
 			// For now, just leave the messages there marked as sent by "not found" user.
 
 			// Delete topics where the user is the owner:
+			if len(topicIds) > 0 {
+				// 1. Delete dellog
+				// 2. Decrement fileuploads.
+				// 3. Delete all messages.
+				// 4. Delete subscriptions.
 
-			// 1. Delete dellog
-			// 2. Decrement fileuploads.
-			// 3. Delete all messages.
-			// 4. Delete subscriptions.
+				// Delete dellog entries.
+				_, err = a.db.Collection("dellog").DeleteMany(sc, topicFilter)
+				if err != nil {
+					return err
+				}
 
-			// Delete user's subscriptions in all topics.
-			if err = a.subsDelete(sc, b.M{"user": uid.String()}, true); err != nil {
-				return err
+				// Decrement fileuploads UseCounter
+				// First get array of attachments IDs that were used in messages of topics from topicIds
+				// Then decrement the usecount field of these file records
+				err := a.fileDecrementUseCounter(sc, b.M{"topic": b.M{"$in": topicIds}})
+				if err != nil {
+					return err
+				}
+
+				// Delete messages
+				_, err = a.db.Collection("messages").DeleteMany(sc, topicFilter)
+				if err != nil {
+					return err
+				}
+
+				// Delete subscriptions
+				_, err = a.db.Collection("subscriptions").DeleteMany(sc, topicFilter)
+				if err != nil {
+					return err
+				}
+
+				// And finally delete the topics.
+				if _, err = a.db.Collection("topics").DeleteMany(sc, b.M{"owner": forUser}); err != nil {
+					return err
+				}
 			}
 
-			// Delete dellog
-			_, err = a.db.Collection("dellog").DeleteMany(sc, topicFilter)
+			// Select all other topics where the user is a subscriber.
+			topicIds, err = a.db.Collection("subscriptions").Distinct(sc, "topic", b.M{"user": forUser})
 			if err != nil {
 				return err
 			}
 
-			// Decrement fileuploads UseCounter
-			// First get array of attachments IDs that were used in messages of topics from topicIds
-			// Then decrement the usecount field of these file records
-			err := a.fileDecrementUseCounter(sc, b.M{"topic": b.M{"$in": topicIds}})
-			if err != nil {
-				return err
-			}
+			if len(topicIds) > 0 {
+				// Delete user's dellog entries.
+				if _, err = a.db.Collection("dellog").DeleteMany(sc,
+					b.M{"topic": b.M{"$in": topicIds}, "deletedfor": forUser}); err != nil {
+					return err
+				}
 
-			// Delete messages
-			_, err = a.db.Collection("messages").DeleteMany(sc, topicFilter)
-			if err != nil {
-				return err
-			}
+				// Delete user's markings of soft-deleted messages
+				filter := b.M{"topic": b.M{"$in": topicIds}, "deletedfor.user": forUser}
+				if _, err = a.db.Collection("messages").
+					UpdateMany(sc, filter, b.M{"$pull": b.M{"deletedfor": b.M{"user": forUser}}}); err != nil {
+					return err
+				}
 
-			// Delete subscriptions
-			_, err = a.db.Collection("subscriptions").DeleteMany(sc, topicFilter)
-			if err != nil {
-				return err
-			}
-
-			// And finally delete the topics.
-			if _, err = a.db.Collection("topics").DeleteMany(sc, b.M{"owner": uid.String()}); err != nil {
-				return err
+				// Delete user's subscriptions in all topics.
+				if err = a.subsDelete(sc, b.M{"user": forUser}, true); err != nil {
+					return err
+				}
 			}
 
 			// Delete user's authentication records.
@@ -670,12 +693,12 @@ func (a *adapter) UserDelete(uid t.Uid, hard bool) error {
 			}
 
 			// And finally delete the user.
-			if _, err = a.db.Collection("users").DeleteOne(sc, b.M{"_id": uid.String()}); err != nil {
+			if _, err = a.db.Collection("users").DeleteOne(sc, b.M{"_id": forUser}); err != nil {
 				return err
 			}
 		} else {
 			// Disable user's subscriptions.
-			if err = a.subsDelete(sc, b.M{"user": uid.String()}, false); err != nil {
+			if err = a.subsDelete(sc, b.M{"user": forUser}, false); err != nil {
 				return err
 			}
 
@@ -690,7 +713,7 @@ func (a *adapter) UserDelete(uid t.Uid, hard bool) error {
 			if _, err = a.db.Collection("topics").UpdateMany(sc, b.M{"_id": b.M{"$in": topicIds}}, disable); err != nil {
 				return err
 			}
-			if _, err = a.db.Collection("users").UpdateMany(sc, b.M{"_id": uid.String()}, disable); err != nil {
+			if _, err = a.db.Collection("users").UpdateMany(sc, b.M{"_id": forUser}, disable); err != nil {
 				return err
 			}
 		}
@@ -1729,10 +1752,45 @@ func (a *adapter) SubsUpdate(topic string, user t.Uid, update map[string]interfa
 
 // SubsDelete deletes a single subscription
 func (a *adapter) SubsDelete(topic string, user t.Uid) error {
-	// FIXME: delete user's dellog entries
-	// FIXME: delete user's markings of soft-deleted messages
+	var sess mdb.Session
+	var err error
+	if sess, err = a.conn.StartSession(); err != nil {
+		return err
+	}
+	defer sess.EndSession(a.ctx)
 
-	return a.subsDelete(a.ctx, b.M{"_id": topic + ":" + user.String()}, false)
+	if err = a.maybeStartTransaction(sess); err != nil {
+		return err
+	}
+
+	forUser := user.String()
+
+	if err = mdb.WithSession(a.ctx, sess, func(sc mdb.SessionContext) error {
+		if err := a.subsDelete(sc, b.M{"_id": topic + ":" + forUser}, false); err != nil {
+			return err
+		}
+
+		if !t.IsChannel(topic) {
+
+			// Delete user's dellog entries.
+			if _, err = a.db.Collection("dellog").DeleteMany(sc, b.M{"topic": topic, "deletedfor": forUser}); err != nil {
+				return err
+			}
+
+			// Delete user's markings of soft-deleted messages
+			filter := b.M{"topic": topic, "deletedfor.user": forUser}
+			if _, err = a.db.Collection("messages").
+				UpdateMany(sc, filter, b.M{"$pull": b.M{"deletedfor": b.M{"user": forUser}}}); err != nil {
+				return err
+			}
+		}
+		// Commit changes.
+		return a.maybeCommitTransaction(sc, sess)
+	}); err != nil {
+		return err
+	}
+
+	return err
 }
 
 // Delete/mark deleted subscriptions.
@@ -2088,9 +2146,9 @@ func (a *adapter) MessageAttachments(msgId t.Uid, fids []string) error {
 	return err
 }
 
-// Devices (for push notifications)
+// Devices (for push notifications).
 
-// DeviceUpsert creates or updates a device record
+// DeviceUpsert creates or updates a device record.
 func (a *adapter) DeviceUpsert(uid t.Uid, dev *t.DeviceDef) error {
 	userId := uid.String()
 	var user t.User
@@ -2186,7 +2244,7 @@ func (a *adapter) DeviceGetAll(uids ...t.Uid) (map[t.Uid][]t.DeviceDef, int, err
 	return result, count, cur.Err()
 }
 
-// DeviceDelete deletes a device record
+// DeviceDelete deletes a device record (push token).
 func (a *adapter) DeviceDelete(uid t.Uid, deviceID string) error {
 	var err error
 	filter := b.M{"_id": uid.String()}
@@ -2302,7 +2360,7 @@ func (a *adapter) isDbInitialized() bool {
 	return true
 }
 
-// Required for running adapter tests.
+// GetAdapter is required for running adapter tests.
 func GetAdapter() *adapter {
 	return &adapter{}
 }

--- a/server/db/mysql/adapter.go
+++ b/server/db/mysql/adapter.go
@@ -950,8 +950,8 @@ func (a *adapter) UserGetAll(ids ...t.Uid) ([]t.User, error) {
 		return nil, err
 	}
 
-	var user t.User
 	for rows.Next() {
+		var user t.User
 		if err = rows.StructScan(&user); err != nil {
 			users = nil
 			break
@@ -2415,8 +2415,8 @@ func (a *adapter) MessageGetDeleted(topic string, forUser t.Uid, opts *t.QueryOp
 	}
 
 	var dmsgs []t.DelMessage
-	var dmsg t.DelMessage
 	for rows.Next() {
+		var dmsg t.DelMessage
 		if err = rows.StructScan(&dellog); err != nil {
 			dmsgs = nil
 			break

--- a/server/pres.go
+++ b/server/pres.go
@@ -64,7 +64,7 @@ func (t *Topic) addToPerSubs(topic string, online, enabled bool) {
 // perSubs contains (a) topics that the user wants to notify of his presence and
 // (b) those which want to receive notifications from this user.
 func (t *Topic) loadContacts(uid types.Uid) error {
-	subs, err := store.Users.GetSubs(uid, nil)
+	subs, err := store.Users.GetSubs(uid)
 	if err != nil {
 		return err
 	}
@@ -263,10 +263,10 @@ func (t *Topic) presUsersOfInterest(what, ua string) {
 // Case A: user is being deleted, "gone"
 func presUsersOfInterestOffline(uid types.Uid, subs []types.Subscription, what string) {
 	// Push update to subscriptions
-	for _, sub := range subs {
+	for i := range subs {
 		globals.hub.route <- &ServerComMessage{
 			Pres:   &MsgServerPres{Topic: "me", What: what, Src: uid.UserId(), WantReply: false},
-			RcptTo: sub.Topic}
+			RcptTo: subs[i].Topic}
 	}
 }
 

--- a/server/store/store.go
+++ b/server/store/store.go
@@ -342,10 +342,10 @@ func (UsersObjMapper) UpdateState(uid types.Uid, state types.ObjState) error {
 	return adp.UserUpdate(uid, update)
 }
 
-// GetSubs loads a list of subscriptions for the given user.
-// Does not load Public, does not load deleted subscriptions.
-func (UsersObjMapper) GetSubs(id types.Uid, opts *types.QueryOpt) ([]types.Subscription, error) {
-	return adp.SubsForUser(id, false, opts)
+// GetSubs loads *all* subscriptions for the given user.
+// Does not load Public or Private, does not load deleted subscriptions.
+func (UsersObjMapper) GetSubs(id types.Uid) ([]types.Subscription, error) {
+	return adp.SubsForUser(id)
 }
 
 // FindSubs find a list of users and topics for the given tags. Results are formatted as subscriptions.

--- a/server/topic.go
+++ b/server/topic.go
@@ -1715,10 +1715,10 @@ func (t *Topic) anotherUserSub(sess *Session, asUid, target types.Uid, asChan bo
 		} else if user.State != types.StateOK {
 			sess.queueOut(ErrPermissionDeniedReply(pkt, now))
 			return nil, errors.New("user is suspended")
+		} else {
+			// Don't ask by default for more permissions than the granted ones.
+			modeWant = user.Access.Auth & modeGiven
 		}
-
-		// Don't ask by default for more permissions than the granted ones.
-		modeWant = user.Access.Auth & modeGiven
 
 		// Add subscription to database
 		sub := &types.Subscription{

--- a/server/topic.go
+++ b/server/topic.go
@@ -1715,10 +1715,10 @@ func (t *Topic) anotherUserSub(sess *Session, asUid, target types.Uid, asChan bo
 		} else if user.State != types.StateOK {
 			sess.queueOut(ErrPermissionDeniedReply(pkt, now))
 			return nil, errors.New("user is suspended")
-		} else {
-			// Don't ask by default for more permissions than the granted ones.
-			modeWant = user.Access.Auth & modeGiven
 		}
+
+		// Don't ask by default for more permissions than the granted ones.
+		modeWant = user.Access.Auth & modeGiven
 
 		// Add subscription to database
 		sub := &types.Subscription{

--- a/server/user.go
+++ b/server/user.go
@@ -604,7 +604,7 @@ func replyDelUser(s *Session, msg *ClientComMessage) {
 	<-done
 
 	// Notify users of interest that the user is gone.
-	if uoi, err := store.Users.GetSubs(uid, nil); err == nil {
+	if uoi, err := store.Users.GetSubs(uid); err == nil {
 		presUsersOfInterestOffline(uid, uoi, "gone")
 	} else {
 		logs.Warn.Println("replyDelUser: failed to send notifications to users", err, s.sid)


### PR DESCRIPTION
* Soft-deleted message records were not properly cleaned up on user and subscription deletions. The same fix as in rethink & mysql.
* Bug fixed in standalone mongo when deletions were failing with '(IllegalOperation) Transaction numbers are only allowed on a replica set member or mongos' due to `RetriableWrites` being `true` by default.
* Fix for #631 (reused slices)
* Removed unused parameters from adapter.SubsForUser (first step for #604)