### PR TITLE
Make relative paths resolve against executable directory.

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -276,12 +276,13 @@ func main() {
 	// All relative paths are resolved against the executable path, not against current working directory.
 	// Absolute paths are left unchanged.
 	rootpath, _ := filepath.Split(executable)
+	curwd, _ := os.Getwd()
 
 	logs.Info.Printf("Server v%s:%s:%s; pid %d; %d process(es)",
 		currentVersion, executable, buildstamp,
 		os.Getpid(), runtime.GOMAXPROCS(runtime.NumCPU()))
 
-	*configfile = toAbsolutePath(rootpath, *configfile)
+	*configfile = toAbsolutePath(curwd, *configfile)
 	logs.Info.Printf("Using config from '%s'", *configfile)
 
 	var config configType
@@ -334,7 +335,7 @@ func main() {
 	workerId := clusterInit(config.Cluster, clusterSelf)
 
 	if *pprofFile != "" {
-		*pprofFile = toAbsolutePath(rootpath, *pprofFile)
+		*pprofFile = toAbsolutePath(curwd, *pprofFile)
 
 		cpuf, err := os.Create(*pprofFile + ".cpu")
 		if err != nil {

--- a/tinode-db/main.go
+++ b/tinode-db/main.go
@@ -168,16 +168,7 @@ func getPassword(n int) string {
 	return string(b)
 }
 
-func toAbsolutePath(base, path string) string {
-	if filepath.IsAbs(path) {
-		return path
-	}
-	return filepath.Clean(filepath.Join(base, path))
-}
-
 func main() {
-	executable, _ := os.Executable()
-
 	reset := flag.Bool("reset", false, "force database reset")
 	upgrade := flag.Bool("upgrade", false, "perform database version upgrade")
 	noInit := flag.Bool("no_init", false, "check that database exists but don't create if missing")
@@ -186,13 +177,8 @@ func main() {
 
 	flag.Parse()
 
-	// All relative paths are resolved against the executable path, not against current working directory.
-	// Absolute paths are left unchanged.
-	rootpath, _ := filepath.Split(executable)
-
 	var data Data
 	if *datafile != "" && *datafile != "-" {
-		*datafile = toAbsolutePath(rootpath, *datafile)
 		raw, err := ioutil.ReadFile(*datafile)
 		if err != nil {
 			log.Fatalln("Failed to read sample data file:", err)
@@ -206,7 +192,6 @@ func main() {
 	rand.Seed(time.Now().UnixNano())
 	data.datapath, _ = filepath.Split(*datafile)
 
-	*conffile = toAbsolutePath(rootpath, *conffile)
 	var config configType
 	if file, err := os.Open(*conffile); err != nil {
 		log.Fatalln("Failed to read config file:", err)


### PR DESCRIPTION
To make things consistent with how the server treats paths.