### PR TITLE
Fix 'me' subs

### DIFF
--- a/server/db/mysql/adapter.go
+++ b/server/db/mysql/adapter.go
@@ -1451,7 +1451,7 @@ func (a *adapter) TopicsForUser(uid t.Uid, keepDeleted bool, opts *t.QueryOpt) (
 
 	if limit > 0 {
 		q += " LIMIT ?"
-		args = append(args, a.maxResults)
+		args = append(args, limit)
 	}
 
 	ctx, cancel := a.getContext()
@@ -1556,7 +1556,7 @@ func (a *adapter) TopicsForUser(uid t.Uid, keepDeleted bool, opts *t.QueryOpt) (
 
 			sub = join[top.Id]
 			// Check if sub.UpdatedAt needs to be adjusted to earlier time.
-			// top.UpdatedAt is guaranted to be after ims.
+			// top.UpdatedAt is guaranteed to be after IMS.
 			if sub.UpdatedAt.Before(ims) {
 				// Subscription has not changed recently, use topic's update timestamp.
 				sub.UpdatedAt = top.UpdatedAt

--- a/server/db/mysql/adapter.go
+++ b/server/db/mysql/adapter.go
@@ -1478,8 +1478,8 @@ func (a *adapter) TopicsForUser(uid t.Uid, keepDeleted bool, opts *t.QueryOpt) (
 		sub.User = uid.String()
 		tcat := t.GetTopicCat(tname)
 
-		if tcat == t.TopicCatMe || tcat == t.TopicCatFnd || tcat == t.TopicCatSys {
-			// One of 'me', 'fnd', 'sys' subscriptions, skip.
+		if tcat == t.TopicCatMe || tcat == t.TopicCatFnd {
+			// One of 'me', 'fnd' subscriptions, skip. Don't skip 'sys' subscription.
 			continue
 		} else if tcat == t.TopicCatP2P {
 			// P2P subscription, find the other user to get user.Public
@@ -1492,7 +1492,7 @@ func (a *adapter) TopicsForUser(uid t.Uid, keepDeleted bool, opts *t.QueryOpt) (
 			topq = append(topq, tname)
 
 		} else {
-			// Group subscription. Maybe convert channel name to topic name.
+			// Group or 'sys' subscription. Maybe convert channel name to topic name.
 			tname = t.ChnToGrp(tname)
 			topq = append(topq, tname)
 		}


### PR DESCRIPTION
The logic of this change is to allow browsing of subscriptions by `updatedAt` timestamp. The original change was wrong: it did not take into account that the subscription's `updatedAt` as seen by the client includes changes to the topic's or user's `updatedAt`.

This fixes just the mysql adapter. The other two have to be fixed too.