### PR TITLE
Got rid of sessionJoin and sessionLeave wrappers

### DIFF
--- a/server/cluster.go
+++ b/server/cluster.go
@@ -492,12 +492,9 @@ func (c *Cluster) TopicMaster(msg *ClusterReq, rejected *bool) error {
 
 	switch msg.ReqType {
 	case ProxyReqJoin:
-		join := &sessionJoin{
-			pkt:  msg.CliMsg,
-			sess: sess,
-		}
+		msg.CliMsg.sess = sess
 		select {
-		case globals.hub.join <- join:
+		case globals.hub.join <- msg.CliMsg:
 		default:
 			// Reply with a 500 to the user.
 			sess.queueOut(ErrUnknownReply(msg.CliMsg, msg.CliMsg.Timestamp))

--- a/server/datamodel.go
+++ b/server/datamodel.go
@@ -350,6 +350,8 @@ type ClientComMessage struct {
 
 	// Originating session to send an aknowledgement to.
 	sess *Session
+	// The message is initialized (true) as opposite to being used as a wrapper for session.
+	init bool
 }
 
 /****************************************************************

--- a/server/hub.go
+++ b/server/hub.go
@@ -29,15 +29,6 @@ var requestLatencyDistribution = []float64{1, 2, 3, 4, 5, 6, 8, 10, 13, 16, 20, 
 var outgoingMessageSizeDistribution = []float64{1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 16384,
 	65536, 262144, 1048576, 4194304, 16777216, 67108864, 268435456, 1073741824, 4294967296}
 
-/*
-// Request to hub to subscribe session to topic
-type sessionJoin struct {
-	// Message, containing request details.
-	pkt *ClientComMessage
-	// Session to attach to topic.
-	sess *Session
-}
-*/
 
 // Session wants to leave the topic
 type sessionLeave struct {

--- a/server/hub.go
+++ b/server/hub.go
@@ -29,16 +29,6 @@ var requestLatencyDistribution = []float64{1, 2, 3, 4, 5, 6, 8, 10, 13, 16, 20, 
 var outgoingMessageSizeDistribution = []float64{1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 16384,
 	65536, 262144, 1048576, 4194304, 16777216, 67108864, 268435456, 1073741824, 4294967296}
 
-/*
-// Session wants to leave the topic
-type sessionLeave struct {
-	// Message, containing request details. Could be nil.
-	pkt *ClientComMessage
-	// Session which initiated the request
-	sess *Session
-}
-*/
-
 // Request to hub to remove the topic
 type topicUnreg struct {
 	// Original request, could be nil.

--- a/server/hub.go
+++ b/server/hub.go
@@ -29,7 +29,7 @@ var requestLatencyDistribution = []float64{1, 2, 3, 4, 5, 6, 8, 10, 13, 16, 20, 
 var outgoingMessageSizeDistribution = []float64{1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 16384,
 	65536, 262144, 1048576, 4194304, 16777216, 67108864, 268435456, 1073741824, 4294967296}
 
-
+/*
 // Session wants to leave the topic
 type sessionLeave struct {
 	// Message, containing request details. Could be nil.
@@ -37,6 +37,7 @@ type sessionLeave struct {
 	// Session which initiated the request
 	sess *Session
 }
+*/
 
 // Request to hub to remove the topic
 type topicUnreg struct {
@@ -79,7 +80,7 @@ type Hub struct {
 	// Channel for routing server-generated messages, buffered at 4096
 	routeSrv chan *ServerComMessage
 
-	// subscribe session to topic, possibly creating a new topic, buffered at 32
+	// subscribe session to topic, possibly creating a new topic, buffered at 256
 	join chan *ClientComMessage
 
 	// Remove topic from hub, possibly deleting it afterwards, buffered at 32

--- a/server/hub.go
+++ b/server/hub.go
@@ -186,7 +186,7 @@ func (h *Hub) run() {
 					clientMsg: make(chan *ClientComMessage, 192),
 					serverMsg: make(chan *ServerComMessage, 64),
 					reg:       make(chan *ClientComMessage, 256),
-					unreg:     make(chan *sessionLeave, 256),
+					unreg:     make(chan *ClientComMessage, 256),
 					meta:      make(chan *ClientComMessage, 64),
 					perUser:   make(map[types.Uid]perUserData),
 					exit:      make(chan *shutDown, 1),

--- a/server/init_topic.go
+++ b/server/init_topic.go
@@ -67,26 +67,25 @@ func topicInit(t *Topic, join *ClientComMessage, h *Hub) {
 
 		// Re-queue pending requests to join the topic.
 		for len(t.reg) > 0 {
-			reg := <-t.reg
-			h.join <- reg
+			h.join <- (<-t.reg)
 		}
 
 		// Reject all other pending requests
 		for len(t.clientMsg) > 0 {
 			msg := <-t.clientMsg
-			if msg.Id != "" {
+			if msg.init {
 				msg.sess.queueOut(ErrLockedExplicitTs(msg.Id, t.xoriginal, timestamp, join.Timestamp))
 			}
 		}
 		for len(t.unreg) > 0 {
 			msg := <-t.unreg
-			if msg.pkt != nil {
-				msg.sess.queueOut(ErrLockedReply(msg.pkt, timestamp))
+			if msg.init {
+				msg.sess.queueOut(ErrLockedReply(msg, timestamp))
 			}
 		}
 		for len(t.meta) > 0 {
 			msg := <-t.meta
-			if msg.Id != "" {
+			if msg.init {
 				msg.sess.queueOut(ErrLockedReply(msg, timestamp))
 			}
 		}

--- a/server/session.go
+++ b/server/session.go
@@ -227,7 +227,7 @@ func (s *Session) unsubAll() {
 
 	for _, sub := range s.subs {
 		// sub.done is the same as topic.unreg
-		// Еhe whole session is being dropped.
+		// The whole session is being dropped.
 		sub.done <- &ClientComMessage{sess: s}
 	}
 }

--- a/server/session.go
+++ b/server/session.go
@@ -628,11 +628,9 @@ func (s *Session) subscribe(msg *ClientComMessage) {
 		s.queueOut(InfoAlreadySubscribed(msg.Id, msg.Original, msg.Timestamp))
 	} else {
 		s.inflightReqs.Add(1)
+		msg.sess = s
 		select {
-		case globals.hub.join <- &sessionJoin{
-			pkt:  msg,
-			sess: s,
-		}:
+		case globals.hub.join <- msg:
 		default:
 			// Reply with a 500 to the user.
 			s.queueOut(ErrUnknownReply(msg, msg.Timestamp))

--- a/server/session_test.go
+++ b/server/session_test.go
@@ -224,7 +224,7 @@ func TestDispatchSubscribe(t *testing.T) {
 	go s.testWriteLoop(&r, &wg)
 
 	hub := &Hub{
-		join: make(chan *sessionJoin, 10),
+		join: make(chan *ClientComMessage, 10),
 	}
 	globals.hub = hub
 
@@ -255,7 +255,7 @@ func TestDispatchSubscribe(t *testing.T) {
 		if join.sess != s {
 			t.Error("Hub.join request: sess field expected to be the session under test.")
 		}
-		if join.pkt != msg {
+		if join != msg {
 			t.Error("Hub.join request: subscribe message expected to be the original subscribe message.")
 		}
 	} else {
@@ -314,7 +314,7 @@ func TestDispatchSubscribeJoinChannelFull(t *testing.T) {
 
 	hub := &Hub{
 		// Make it unbuffered with no readers - so emit operation fails immediately.
-		join: make(chan *sessionJoin),
+		join: make(chan *ClientComMessage),
 	}
 	globals.hub = hub
 

--- a/server/session_test.go
+++ b/server/session_test.go
@@ -355,7 +355,7 @@ func TestDispatchLeave(t *testing.T) {
 
 	destUid := types.Uid(2)
 	topicName := uid.P2PName(destUid)
-	leave := make(chan *sessionLeave, 1)
+	leave := make(chan *ClientComMessage, 1)
 	s.subs = make(map[string]*Subscription)
 	s.subs[topicName] = &Subscription{
 		done: leave,
@@ -381,7 +381,7 @@ func TestDispatchLeave(t *testing.T) {
 		if req.sess != s {
 			t.Error("Leave request: sess field expected to be the session under test.")
 		}
-		if req.pkt != msg {
+		if req != msg {
 			t.Error("Leave request: leave message expected to be the original leave message.")
 		}
 	} else {

--- a/server/store/mock_store/mock_store.go
+++ b/server/store/mock_store/mock_store.go
@@ -11,6 +11,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	auth "github.com/tinode/chat/server/auth"
+	adapter "github.com/tinode/chat/server/db"
 	media "github.com/tinode/chat/server/media"
 	types "github.com/tinode/chat/server/store/types"
 	validate "github.com/tinode/chat/server/validate"
@@ -65,6 +66,20 @@ func (m *MockPersistentStorageInterface) DbStats() func() interface{} {
 func (mr *MockPersistentStorageInterfaceMockRecorder) DbStats() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DbStats", reflect.TypeOf((*MockPersistentStorageInterface)(nil).DbStats))
+}
+
+// GetAdapter mocks base method.
+func (m *MockPersistentStorageInterface) GetAdapter() adapter.Adapter {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAdapter")
+	ret0, _ := ret[0].(adapter.Adapter)
+	return ret0
+}
+
+// GetAdapter indicates an expected call of GetAdapter.
+func (mr *MockPersistentStorageInterfaceMockRecorder) GetAdapter() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAdapter", reflect.TypeOf((*MockPersistentStorageInterface)(nil).GetAdapter))
 }
 
 // GetAdapterName mocks base method.
@@ -617,21 +632,6 @@ func (m *MockUsersPersistenceInterface) GetUnreadCount(id types.Uid) (int, error
 func (mr *MockUsersPersistenceInterfaceMockRecorder) GetUnreadCount(id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnreadCount", reflect.TypeOf((*MockUsersPersistenceInterface)(nil).GetUnreadCount), id)
-}
-
-// IsOwner mocks base method.
-func (m *MockUsersPersistenceInterface) IsOwner(id types.Uid, topic string) (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsOwner", id, topic)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// IsOwner indicates an expected call of IsOwner.
-func (mr *MockUsersPersistenceInterfaceMockRecorder) IsOwner(id, topic interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsOwner", reflect.TypeOf((*MockUsersPersistenceInterface)(nil).IsOwner), id, topic)
 }
 
 // Update mocks base method.

--- a/server/topic_proxy.go
+++ b/server/topic_proxy.go
@@ -23,8 +23,8 @@ func (t *Topic) runProxy(hub *Hub) {
 		case join := <-t.reg:
 			// Request to add a connection to this topic
 			if t.isInactive() {
-				join.sess.queueOut(ErrLockedReply(join.pkt, types.TimeNow()))
-			} else if err := globals.cluster.routeToTopicMaster(ProxyReqJoin, join.pkt, t.name, join.sess); err != nil {
+				join.sess.queueOut(ErrLockedReply(join, types.TimeNow()))
+			} else if err := globals.cluster.routeToTopicMaster(ProxyReqJoin, join, t.name, join.sess); err != nil {
 				// Response (ctrl message) will be handled when it's received via the proxy channel.
 				logs.Warn.Println("proxy topic: route join request from proxy to master failed:", err)
 			}

--- a/server/topic_test.go
+++ b/server/topic_test.go
@@ -1224,15 +1224,13 @@ func TestRegisterSessionMe(t *testing.T) {
 	}
 
 	for i, s := range helper.sessions {
-		join := &sessionJoin{
-			pkt: &ClientComMessage{
-				Sub: &MsgClientSub{
-					Id:    fmt.Sprintf("id456-%d", i),
-					Topic: "me",
-				},
-				AsUser: uid.UserId(),
+		join := &ClientComMessage{
+			Sub: &MsgClientSub{
+				Id:    fmt.Sprintf("id456-%d", i),
+				Topic: "me",
 			},
-			sess: s,
+			AsUser: uid.UserId(),
+			sess:   s,
 		}
 		helper.topic.registerSession(join)
 	}
@@ -1274,15 +1272,13 @@ func TestRegisterSessionInactiveTopic(t *testing.T) {
 	uid := helper.uids[0]
 
 	s := helper.sessions[0]
-	join := &sessionJoin{
-		pkt: &ClientComMessage{
-			Sub: &MsgClientSub{
-				Id:    "id456",
-				Topic: "me",
-			},
-			AsUser: uid.UserId(),
+	join := &ClientComMessage{
+		Sub: &MsgClientSub{
+			Id:    "id456",
+			Topic: "me",
 		},
-		sess: s,
+		AsUser: uid.UserId(),
+		sess:   s,
 	}
 
 	// Deactivate topic.
@@ -1320,22 +1316,20 @@ func TestRegisterSessionUserSpecifiedInSetMessage(t *testing.T) {
 	uid := helper.uids[0]
 
 	s := helper.sessions[0]
-	join := &sessionJoin{
-		pkt: &ClientComMessage{
-			Original: topicName,
-			Sub: &MsgClientSub{
-				Id:    "id456",
-				Topic: topicName,
-				Set: &MsgSetQuery{
-					Sub: &MsgSetSub{
-						// Specify the user. This should result in an error.
-						User: "foo",
-					},
+	join := &ClientComMessage{
+		Original: topicName,
+		Sub: &MsgClientSub{
+			Id:    "id456",
+			Topic: topicName,
+			Set: &MsgSetQuery{
+				Sub: &MsgSetSub{
+					// Specify the user. This should result in an error.
+					User: "foo",
 				},
 			},
-			AsUser: uid.UserId(),
 		},
-		sess: s,
+		AsUser: uid.UserId(),
+		sess:   s,
 	}
 
 	helper.topic.registerSession(join)
@@ -1370,22 +1364,20 @@ func TestRegisterSessionInvalidWantStrInSetMessage(t *testing.T) {
 	uid := helper.uids[0]
 
 	s := helper.sessions[0]
-	join := &sessionJoin{
-		pkt: &ClientComMessage{
-			Original: topicName,
-			Sub: &MsgClientSub{
-				Id:    "id456",
-				Topic: topicName,
-				Set: &MsgSetQuery{
-					Sub: &MsgSetSub{
-						// Specify the user. This should result in an error.
-						Mode: "Invalid mode string",
-					},
+	join := &ClientComMessage{
+		Original: topicName,
+		Sub: &MsgClientSub{
+			Id:    "id456",
+			Topic: topicName,
+			Set: &MsgSetQuery{
+				Sub: &MsgSetSub{
+					// Specify the user. This should result in an error.
+					Mode: "Invalid mode string",
 				},
 			},
-			AsUser: uid.UserId(),
 		},
-		sess: s,
+		AsUser: uid.UserId(),
+		sess:   s,
 	}
 
 	helper.topic.registerSession(join)
@@ -1429,16 +1421,14 @@ func TestRegisterSessionMaxSubscriberCountExceeded(t *testing.T) {
 	helper.sessions = append(helper.sessions, s)
 	helper.results = append(helper.results, r)
 
-	join := &sessionJoin{
-		pkt: &ClientComMessage{
-			Original: topicName,
-			Sub: &MsgClientSub{
-				Id:    "id456",
-				Topic: topicName,
-			},
-			AsUser: uid.UserId(),
+	join := &ClientComMessage{
+		Original: topicName,
+		Sub: &MsgClientSub{
+			Id:    "id456",
+			Topic: topicName,
 		},
-		sess: s,
+		AsUser: uid.UserId(),
+		sess:   s,
 	}
 
 	helper.topic.registerSession(join)
@@ -1478,16 +1468,14 @@ func TestRegisterSessionLowAuthLevelWithSysTopic(t *testing.T) {
 	helper.sessions = append(helper.sessions, s)
 	helper.results = append(helper.results, r)
 
-	join := &sessionJoin{
-		pkt: &ClientComMessage{
-			Original: topicName,
-			Sub: &MsgClientSub{
-				Id:    "id456",
-				Topic: topicName,
-			},
-			AsUser: uid.UserId(),
+	join := &ClientComMessage{
+		Original: topicName,
+		Sub: &MsgClientSub{
+			Id:    "id456",
+			Topic: topicName,
 		},
-		sess: s,
+		AsUser: uid.UserId(),
+		sess:   s,
 	}
 
 	helper.topic.registerSession(join)
@@ -1529,16 +1517,14 @@ func TestRegisterSessionNewChannelGetSubDbError(t *testing.T) {
 	helper.sessions = append(helper.sessions, s)
 	helper.results = append(helper.results, r)
 
-	join := &sessionJoin{
-		pkt: &ClientComMessage{
-			Original: chanName,
-			Sub: &MsgClientSub{
-				Id:    "id456",
-				Topic: chanName,
-			},
-			AsUser: uid.UserId(),
+	join := &ClientComMessage{
+		Original: chanName,
+		Sub: &MsgClientSub{
+			Id:    "id456",
+			Topic: chanName,
 		},
-		sess: s,
+		AsUser: uid.UserId(),
+		sess:   s,
 	}
 
 	helper.ss.EXPECT().Get(chanName, uid).Return(nil, types.ErrInternal)
@@ -1579,17 +1565,15 @@ func TestRegisterSessionCreateSubFailed(t *testing.T) {
 	helper.sessions = append(helper.sessions, s)
 	helper.results = append(helper.results, r)
 
-	join := &sessionJoin{
-		pkt: &ClientComMessage{
-			Original: topicName,
-			Sub: &MsgClientSub{
-				Id:    "id456",
-				Topic: topicName,
-			},
-			AsUser:  uid.UserId(),
-			AuthLvl: int(auth.LevelAuth),
+	join := &ClientComMessage{
+		Original: topicName,
+		Sub: &MsgClientSub{
+			Id:    "id456",
+			Topic: topicName,
 		},
-		sess: s,
+		AsUser:  uid.UserId(),
+		AuthLvl: int(auth.LevelAuth),
+		sess:    s,
 	}
 
 	helper.ss.EXPECT().Create(gomock.Any()).Return(types.ErrInternal)
@@ -1631,17 +1615,15 @@ func TestRegisterSessionAsChanUserNotChanSubcriber(t *testing.T) {
 	r := helper.results[0]
 
 	// User is not a channel subscriber (userData.isChan is false).
-	join := &sessionJoin{
-		pkt: &ClientComMessage{
-			Original: chanName,
-			Sub: &MsgClientSub{
-				Id:    "id456",
-				Topic: chanName,
-			},
-			AsUser:  uid.UserId(),
-			AuthLvl: int(auth.LevelAuth),
+	join := &ClientComMessage{
+		Original: chanName,
+		Sub: &MsgClientSub{
+			Id:    "id456",
+			Topic: chanName,
 		},
-		sess: s,
+		AsUser:  uid.UserId(),
+		AuthLvl: int(auth.LevelAuth),
+		sess:    s,
 	}
 
 	helper.topic.registerSession(join)
@@ -1683,23 +1665,21 @@ func TestRegisterSessionOwnerBansHimself(t *testing.T) {
 	pud.modeGiven |= types.ModeOwner
 	helper.topic.perUser[uid] = pud
 
-	join := &sessionJoin{
-		pkt: &ClientComMessage{
-			Original: topicName,
-			Sub: &MsgClientSub{
-				Id:    "id456",
-				Topic: topicName,
-				Set: &MsgSetQuery{
-					Sub: &MsgSetSub{
-						// No O permission.
-						Mode: "JPRW",
-					},
+	join := &ClientComMessage{
+		Original: topicName,
+		Sub: &MsgClientSub{
+			Id:    "id456",
+			Topic: topicName,
+			Set: &MsgSetQuery{
+				Sub: &MsgSetSub{
+					// No O permission.
+					Mode: "JPRW",
 				},
 			},
-			AsUser:  uid.UserId(),
-			AuthLvl: int(auth.LevelAuth),
 		},
-		sess: s,
+		AsUser:  uid.UserId(),
+		AuthLvl: int(auth.LevelAuth),
+		sess:    s,
 	}
 
 	helper.topic.registerSession(join)
@@ -1741,23 +1721,21 @@ func TestRegisterSessionInvalidOwnershipTransfer(t *testing.T) {
 	pud.modeGiven = types.ModeCPublic
 	helper.topic.perUser[uid] = pud
 
-	join := &sessionJoin{
-		pkt: &ClientComMessage{
-			Original: topicName,
-			Sub: &MsgClientSub{
-				Id:    "id456",
-				Topic: topicName,
-				Set: &MsgSetQuery{
-					Sub: &MsgSetSub{
-						// Want ownership.
-						Mode: "JPRWSO",
-					},
+	join := &ClientComMessage{
+		Original: topicName,
+		Sub: &MsgClientSub{
+			Id:    "id456",
+			Topic: topicName,
+			Set: &MsgSetQuery{
+				Sub: &MsgSetSub{
+					// Want ownership.
+					Mode: "JPRWSO",
 				},
 			},
-			AsUser:  uid.UserId(),
-			AuthLvl: int(auth.LevelAuth),
 		},
-		sess: s,
+		AsUser:  uid.UserId(),
+		AuthLvl: int(auth.LevelAuth),
+		sess:    s,
 	}
 
 	helper.topic.registerSession(join)
@@ -1800,21 +1778,20 @@ func TestRegisterSessionMetadataUpdateFails(t *testing.T) {
 
 	// Want ownership.
 	newWant := "JRWP"
-	join := &sessionJoin{
-		pkt: &ClientComMessage{
-			Original: topicName,
-			Sub: &MsgClientSub{
-				Id:    "id456",
-				Topic: topicName,
-				Set: &MsgSetQuery{
-					Sub: &MsgSetSub{
-						Mode: newWant,
-					},
+	join := &ClientComMessage{
+		Original: topicName,
+		Sub: &MsgClientSub{
+			Id:    "id456",
+			Topic: topicName,
+			Set: &MsgSetQuery{
+				Sub: &MsgSetSub{
+					Mode: newWant,
 				},
 			},
-			AsUser:  uid.UserId(),
-			AuthLvl: int(auth.LevelAuth),
 		},
+		AsUser:  uid.UserId(),
+		AuthLvl: int(auth.LevelAuth),
+
 		sess: s,
 	}
 	// DB call fails.
@@ -1860,22 +1837,20 @@ func TestRegisterSessionOwnerChangeDbCallFails(t *testing.T) {
 
 	// Want ownership.
 	newWant := "JRWPASO"
-	join := &sessionJoin{
-		pkt: &ClientComMessage{
-			Original: topicName,
-			Sub: &MsgClientSub{
-				Id:    "id456",
-				Topic: topicName,
-				Set: &MsgSetQuery{
-					Sub: &MsgSetSub{
-						Mode: newWant,
-					},
+	join := &ClientComMessage{
+		Original: topicName,
+		Sub: &MsgClientSub{
+			Id:    "id456",
+			Topic: topicName,
+			Set: &MsgSetQuery{
+				Sub: &MsgSetSub{
+					Mode: newWant,
 				},
 			},
-			AsUser:  uid.UserId(),
-			AuthLvl: int(auth.LevelAuth),
 		},
-		sess: s,
+		AsUser:  uid.UserId(),
+		AuthLvl: int(auth.LevelAuth),
+		sess:    s,
 	}
 	helper.ss.EXPECT().Update(topicName, uid, gomock.Any()).Return(nil).Times(2)
 	// OwnerChange call fails.

--- a/server/topic_test.go
+++ b/server/topic_test.go
@@ -1905,17 +1905,16 @@ func TestUnregisterSessionSimple(t *testing.T) {
 
 	s := helper.sessions[0]
 	r := helper.results[0]
-	leave := &sessionLeave{
-		pkt: &ClientComMessage{
-			Leave: &MsgClientLeave{
-				Id:    "id456",
-				Topic: topicName,
-			},
-			AsUser: uid.UserId(),
+	leave := &ClientComMessage{
+		Leave: &MsgClientLeave{
+			Id:    "id456",
+			Topic: topicName,
 		},
-		sess: s,
+		AsUser: uid.UserId(),
+		sess:   s,
+		init:   true,
 	}
-	helper.topic.unregisterSession(leave.pkt, leave.sess)
+	helper.topic.unregisterSession(leave)
 
 	helper.finish()
 
@@ -1956,21 +1955,20 @@ func TestUnregisterSessionInactiveTopic(t *testing.T) {
 
 	s := helper.sessions[0]
 	r := helper.results[0]
-	leave := &sessionLeave{
-		pkt: &ClientComMessage{
-			Leave: &MsgClientLeave{
-				Id:    "id456",
-				Topic: topicName,
-			},
-			AsUser: uid.UserId(),
+	leave := &ClientComMessage{
+		Leave: &MsgClientLeave{
+			Id:    "id456",
+			Topic: topicName,
 		},
-		sess: s,
+		AsUser: uid.UserId(),
+		sess:   s,
+		init:   true,
 	}
 
 	// Deactivate topic.
 	helper.topic.markDeleted()
 
-	helper.topic.unregisterSession(leave.pkt, leave.sess)
+	helper.topic.unregisterSession(leave)
 	helper.finish()
 
 	if len(helper.topic.sessions) != 1 {
@@ -2020,18 +2018,17 @@ func TestUnregisterSessionUnsubscribe(t *testing.T) {
 		t.Errorf("Number of online sessions: expected 3 vs found %d", online)
 	}
 
-	leave := &sessionLeave{
-		pkt: &ClientComMessage{
-			Leave: &MsgClientLeave{
-				Id:    "id456",
-				Topic: topicName,
-				Unsub: true,
-			},
-			AsUser: uid.UserId(),
+	leave := &ClientComMessage{
+		Leave: &MsgClientLeave{
+			Id:    "id456",
+			Topic: topicName,
+			Unsub: true,
 		},
-		sess: helper.sessions[0],
+		AsUser: uid.UserId(),
+		sess:   helper.sessions[0],
+		init:   true,
 	}
-	helper.topic.unregisterSession(leave.pkt, leave.sess)
+	helper.topic.unregisterSession(leave)
 	helper.finish()
 
 	if len(helper.topic.sessions) != 2 {
@@ -2110,19 +2107,18 @@ func TestUnregisterSessionOwnerCannotUnsubscribe(t *testing.T) {
 	s := helper.sessions[0]
 	r := helper.results[0]
 
-	leave := &sessionLeave{
-		pkt: &ClientComMessage{
-			Leave: &MsgClientLeave{
-				Id:    "id456",
-				Topic: topicName,
-				Unsub: true,
-			},
-			AsUser: uid.UserId(),
+	leave := &ClientComMessage{
+		Leave: &MsgClientLeave{
+			Id:    "id456",
+			Topic: topicName,
+			Unsub: true,
 		},
-		sess: s,
+		AsUser: uid.UserId(),
+		sess:   s,
+		init:   true,
 	}
 
-	helper.topic.unregisterSession(leave.pkt, leave.sess)
+	helper.topic.unregisterSession(leave)
 	helper.finish()
 
 	if len(helper.topic.sessions) != 3 {
@@ -2154,21 +2150,20 @@ func TestUnregisterSessionUnsubDeleteCallFails(t *testing.T) {
 	s := helper.sessions[1]
 	r := helper.results[1]
 
-	leave := &sessionLeave{
-		pkt: &ClientComMessage{
-			Leave: &MsgClientLeave{
-				Id:    "id456",
-				Topic: topicName,
-				Unsub: true,
-			},
-			AsUser: uid.UserId(),
+	leave := &ClientComMessage{
+		Leave: &MsgClientLeave{
+			Id:    "id456",
+			Topic: topicName,
+			Unsub: true,
 		},
-		sess: s,
+		AsUser: uid.UserId(),
+		sess:   s,
+		init:   true,
 	}
 	// DB call fails.
 	helper.ss.EXPECT().Delete(topicName, uid).Return(types.ErrInternal)
 
-	helper.topic.unregisterSession(leave.pkt, leave.sess)
+	helper.topic.unregisterSession(leave)
 	helper.finish()
 
 	if len(helper.topic.sessions) != 3 {


### PR DESCRIPTION
`ClientComMessage` has a `Session` field now. The wrappers are obsolete now.