### PR TITLE
Drafty handling refactored to use trees

### DIFF
--- a/server/auth/basic/auth_basic.go
+++ b/server/auth/basic/auth_basic.go
@@ -23,9 +23,9 @@ const (
 	defaultMinPasswordLength = 3
 )
 
-// Token suitable as a login: starts with a Unicode letter (class L) and contains Unicode letters (L),
-// numbers (N) and underscore.
-var loginPattern = regexp.MustCompile(`^\pL[_\pL\pN]+$`)
+// Token suitable as a login: starts and ends with a Unicode letter (class L) or number (class N),
+// contains Unicode letters, numbers, dot and underscore.
+var loginPattern = regexp.MustCompile(`^[\pL\pN][_.\pL\pN]*[\pL\pN]+$`)
 
 // authenticator is the type to map authentication methods to.
 type authenticator struct {

--- a/server/db/mysql/schema.sql
+++ b/server/db/mysql/schema.sql
@@ -1,3 +1,13 @@
+# THIS SCHEMA FILE IS FOR REFERENCE/DOCUMENTATION ONLY!
+# DO NOT USE IT TO INITIALIZE THE DATABASE.
+# Read installation instructions first.
+
+# The following line will produce an intentional error.
+
+'READ INSTALLATION INSTRUCTIONS!';
+
+# The actual schema is below.
+
 DROP DATABASE IF EXISTS tinode;
 
 CREATE DATABASE tinode CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/server/drafty/drafty.go
+++ b/server/drafty/drafty.go
@@ -53,36 +53,6 @@ type node struct {
 	children []*node
 }
 
-func (n *node) String() string {
-	str := "{"
-	if n == nil {
-		str = "nil"
-	} else {
-		if n.sp != nil {
-			str += n.sp.tp
-			if n.sp.data != nil {
-				str += ":data"
-			}
-			str += ":"
-		}
-
-		if n.txt != nil {
-			str += "'" + string(n.txt) + "'"
-		} else if len(n.children) > 0 {
-			str += "["
-			var sub []string
-			for _, c := range n.children {
-				sub = append(sub, c.String())
-			}
-			str += strings.Join(sub, ",") + "]"
-		} else if n.sp != nil && n.sp.at < 0 {
-			// An attachment.
-			str += "(att)"
-		}
-	}
-	return str + "}"
-}
-
 type previewState struct {
 	drafty    *document
 	maxLength int
@@ -158,6 +128,7 @@ func PlainText(content interface{}) (string, error) {
 	return strings.TrimSpace(string(state.txt)), nil
 }
 
+// styleToSpan converts Drafty style to internal representation.
 func (s *span) styleToSpan(in *style) error {
 	s.tp = in.Tp
 	s.at = in.At
@@ -182,6 +153,7 @@ type spanfmt struct {
 	isVoid bool
 }
 
+// Plain text formatting of the Drafty tags.
 var tags = map[string]spanfmt{
 	"ST": {"*", false},
 	"EM": {"_", false},
@@ -196,6 +168,7 @@ var tags = map[string]spanfmt{
 	"QQ": {"", false},
 }
 
+// Type of the formatter to apply to tree nodes.
 type formatter func(n *node, state interface{}) error
 
 // toTree converts a drafty document into a tree of formatted spans.

--- a/server/drafty/drafty.go
+++ b/server/drafty/drafty.go
@@ -320,6 +320,12 @@ func plainTextFormatter(n *node, ctx interface{}) error {
 		state.txt += text
 	case "BR":
 		state.txt += "\n"
+	case "IC":
+		name, ok := nullableMapGet(n.sp.data, "name")
+		if !ok || name == "" {
+			name = "?"
+		}
+		state.txt += "[ICON:" + name + " " + text + "]"
 	case "IM":
 		name, ok := nullableMapGet(n.sp.data, "name")
 		if !ok || name == "" {

--- a/server/drafty/drafty.go
+++ b/server/drafty/drafty.go
@@ -169,6 +169,9 @@ func Preview(content interface{}, length int) (string, error) {
 			}
 
 			if s.at < textLen {
+				if s.end > textLen {
+					s.end = textLen
+				}
 				styles = append(styles, s)
 				if s.tp == "" {
 					if s.key < 0 {

--- a/server/drafty/drafty.go
+++ b/server/drafty/drafty.go
@@ -153,19 +153,14 @@ type spanfmt struct {
 	isVoid bool
 }
 
-// Plain text formatting of the Drafty tags.
+// Plain text formatting of the Drafty tags. Only non-blank tags need to be listed.
 var tags = map[string]spanfmt{
-	"ST": {"*", false},
-	"EM": {"_", false},
-	"DL": {"~", false},
-	"CO": {"`", false},
 	"BR": {"\n", true},
-	"LN": {"", false},
-	"MN": {"", false},
-	"HT": {"", false},
-	"IM": {"", false},
+	"CO": {"`", false},
+	"DL": {"~", false},
+	"EM": {"_", false},
 	"EX": {"", true},
-	"QQ": {"", false},
+	"ST": {"*", false},
 }
 
 // Type of the formatter to apply to tree nodes.

--- a/server/drafty/drafty_test.go
+++ b/server/drafty/drafty_test.go
@@ -37,6 +37,11 @@ var validInputs = []string{
 		"txt":"мультибайтовый юникод",
 		"fmt":[{"len":14,"tp":"ST"},{"at":15,"len":6,"tp":"EM"}]
 	}`,
+	`{
+		"txt":"Alice Johnson    This is a test",
+		"fmt":[{"at":13,"len":1,"tp":"BR"},{"at":15,"len":1},{"len":13,"key":1},{"len":16,"tp":"QQ"},{"at":16,"len":1,"tp":"BR"}],
+		"ent":[{"tp":"IM","data":{"mime":"image/jpeg","val":"<1292, bytes: /9j/4AAQSkZJ...rehH5o6D/9k=>","width":25,"height":14,"size":968}},{"tp":"MN","data":{"color":2}}]
+	}`,
 }
 
 var invalidInputs = []string{
@@ -80,7 +85,7 @@ func TestToPlainText(t *testing.T) {
 		"This _text has_ staggered formats",
 		"This *text* is _formatted_ and ~deleted *too*~",
 		"*мультибайтовый* _юникод_",
-		"https://api.tinode.co/",
+		"some result",
 	}
 
 	for i := range validInputs {
@@ -118,6 +123,7 @@ func TestPreview(t *testing.T) {
 		`{"txt":"This text has s","fmt":[{"tp":"EM","at":5,"len":8}]}`,
 		`{"txt":"This text is fo","fmt":[{"tp":"ST","at":5,"len":4},{"tp":"EM","at":13,"len":2}]}`,
 		`{"txt":"мультибайтовый ","fmt":[{"tp":"ST","len":14}]}`,
+		`some result`,
 	}
 	for i := range validInputs {
 		var val interface{}

--- a/server/drafty/drafty_test.go
+++ b/server/drafty/drafty_test.go
@@ -26,6 +26,10 @@ var validInputs = []string{
 		"txt":" "
 	}`,
 	`{
+		"txt":"This text has staggered formats",
+		"fmt":[{"at":5,"len":8,"tp":"EM"},{"at":10,"len":13,"tp":"ST"}]
+	}`,
+	`{
 		"txt":"This text is formatted and deleted too",
 		"fmt":[{"at":5,"len":4,"tp":"ST"},{"at":13,"len":9,"tp":"EM"},{"at":35,"len":3,"tp":"ST"},{"at":27,"len":11,"tp":"DL"}]
 	}`,
@@ -73,6 +77,7 @@ func TestToPlainText(t *testing.T) {
 		"[https://api.tinode.co/](https://www.youtube.com/watch?v=dQw4w9WgXcQ)",
 		"https://api.tinode.co/",
 		"[IMAGE 'roses.jpg']",
+		"This _text has_ staggered formats",
 		"This *text* is _formatted_ and ~deleted *too*~",
 		"*мультибайтовый* _юникод_",
 		"https://api.tinode.co/",
@@ -106,12 +111,13 @@ func TestToPlainText(t *testing.T) {
 
 func TestPreview(t *testing.T) {
 	expect := []string{
-		`{"ent":[{"data":{"height":80,"mime":"image/jpeg","name":"hello.jpg","width":100},"tp":"EX"}],"fmt":[{"at":-1,"key":0}]}`,
-		`{"ent":[{"tp":"LN"}],"fmt":[{"key":0,"len":15}],"txt":"https://api.tin"}`,
-		`{"ent":[{"tp":"LN"}],"fmt":[{"key":0,"len":15}],"txt":"https://api.tin"}`,
-		`{"ent":[{"data":{"height":213,"mime":"image/jpeg","name":"roses.jpg","width":638},"tp":"IM"}],"fmt":[{"key":0,"len":1}],"txt":" "}`,
-		`{"fmt":[{"at":5,"len":4,"tp":"ST"},{"at":13,"len":2,"tp":"EM"}],"txt":"This text is fo"}`,
-		`{"fmt":[{"len":14,"tp":"ST"}],"txt":"мультибайтовый "}`,
+		`{"fmt":[{"at":-1}],"ent":[{"tp":"EX","data":{"height":80,"mime":"image/jpeg","name":"hello.jpg","width":100}}]}`,
+		`{"txt":"https://api.tin","fmt":[{"len":15}],"ent":[{"tp":"LN","data":{"url":"https://www.youtube.com/watch?v=dQw4w9WgXcQ"}}]}`,
+		`{"txt":"https://api.tin","fmt":[{"len":15}],"ent":[{"tp":"LN","data":{"url":"https://api.tinode.co/"}}]}`,
+		`{"txt":" ","fmt":[{"len":1}],"ent":[{"tp":"IM","data":{"height":213,"mime":"image/jpeg","name":"roses.jpg","width":638}}]}`,
+		`{"txt":"This text has s","fmt":[{"tp":"EM","at":5,"len":8}]}`,
+		`{"txt":"This text is fo","fmt":[{"tp":"ST","at":5,"len":4},{"tp":"EM","at":13,"len":2}]}`,
+		`{"txt":"мультибайтовый ","fmt":[{"tp":"ST","len":14}]}`,
 	}
 	for i := range validInputs {
 		var val interface{}
@@ -127,7 +133,7 @@ func TestPreview(t *testing.T) {
 	}
 
 	// Only some invalid input should fail these tests.
-	testsToFail := []int{0, 3, 5}
+	testsToFail := []int{3, 4, 5, 6}
 	for _, i := range testsToFail {
 		var val interface{}
 		if err := json.Unmarshal([]byte(invalidInputs[i]), &val); err != nil {

--- a/server/drafty/drafty_test.go
+++ b/server/drafty/drafty_test.go
@@ -52,6 +52,11 @@ var validInputs = []string{
 		"fmt":[{"at":13,"len":1,"tp":"BR"},{"at":15,"len":1},{"len":13,"key":1},{"len":16,"tp":"QQ"},{"at":16,"len":1,"tp":"BR"}],
 		"ent":[{"tp":"IM","data":{"mime":"image/jpeg","val":"<1292, bytes: /9j/4AAQSkZJ...rehH5o6D/9k=>","width":25,"height":14,"size":968}},{"tp":"MN","data":{"color":2}}]
 	}`,
+	`{
+		"txt":"Tino the Chatbot Post responseYesДа reply to a form",
+		"ent":[{"tp":"IC","data":{"orig":"BN","name":"button"}},{"tp":"IC","data":{"orig":"BN","name":"button"}},{"tp":"MN","data":{"colorId":6}}],
+		"fmt":[{"at":30,"len":3},{"at":33,"len":2,"key":1},{"len":16,"key":2}]
+	}`,
 }
 
 var invalidInputs = []string{
@@ -99,6 +104,7 @@ func TestPlainText(t *testing.T) {
 		"This *text* is _formatted_ and ~deleted *too*~",
 		"*мультибайтовый* _юникод_",
 		"This is a test",
+		"Tino the Chatbot Post response[ICON:button Yes][ICON:button Да] reply to a form",
 	}
 
 	for i := range validInputs {
@@ -140,6 +146,7 @@ func TestPreview(t *testing.T) {
 		`{"txt":"This text is fo","fmt":[{"tp":"ST","at":5,"len":4},{"tp":"EM","at":13,"len":2}]}`,
 		`{"txt":"мультибайтовый ","fmt":[{"tp":"ST","len":14}]}`,
 		`{"txt":"This is a test"}`,
+		`{"txt":"Tino the Chatbo","fmt":[{"len":15}],"ent":[{"tp":"MN"}]}`,
 	}
 	for i := range validInputs {
 		var val interface{}

--- a/server/drafty/drafty_test.go
+++ b/server/drafty/drafty_test.go
@@ -61,6 +61,15 @@ var invalidInputs = []string{
 	`{
 		"txt":true
 	}`,
+	`{
+		"ent":["tp":"LN"}],
+		"fmt":[{"len":22}],
+		"txt":"https://api.tinode.co/"
+	}`,
+	`{
+		"invalid":[{"data": true, "tp": "ST"}],
+		"content":[{"len":1,"key":42}],
+	}`,
 }
 
 func TestToPlainText(t *testing.T) {
@@ -78,7 +87,7 @@ func TestToPlainText(t *testing.T) {
 		json.Unmarshal([]byte(validInputs[i]), &val)
 		res, err := ToPlainText(val)
 		if err != nil {
-			t.Error(err)
+			t.Errorf("%d failed with error: %s", i, err)
 		} else if res != expect[i] {
 			t.Errorf("%d output '%s' does not match '%s'", i, res, expect[i])
 		}

--- a/server/drafty/drafty_test.go
+++ b/server/drafty/drafty_test.go
@@ -97,10 +97,10 @@ func TestToPlainText(t *testing.T) {
 func TestPreview(t *testing.T) {
 	expect := []string{
 		`{"ent":[{"data":{"height":80,"mime":"image/jpeg","name":"hello.jpg","width":100},"tp":"EX"}],"fmt":[{"at":-1,"key":0}]}`,
-		`{"ent":[{"tp":"LN"}],"fmt":[{"key":0,"len":22}],"txt":"https://api.tin"}`,
-		`{"ent":[{"tp":"LN"}],"fmt":[{"key":0,"len":22}],"txt":"https://api.tin"}`,
+		`{"ent":[{"tp":"LN"}],"fmt":[{"key":0,"len":15}],"txt":"https://api.tin"}`,
+		`{"ent":[{"tp":"LN"}],"fmt":[{"key":0,"len":15}],"txt":"https://api.tin"}`,
 		`{"ent":[{"data":{"height":213,"mime":"image/jpeg","name":"roses.jpg","width":638},"tp":"IM"}],"fmt":[{"key":0,"len":1}],"txt":" "}`,
-		`{"fmt":[{"at":5,"len":4,"tp":"ST"},{"at":13,"len":9,"tp":"EM"}],"txt":"This text is fo"}`,
+		`{"fmt":[{"at":5,"len":4,"tp":"ST"},{"at":13,"len":2,"tp":"EM"}],"txt":"This text is fo"}`,
 		`{"fmt":[{"len":14,"tp":"ST"}],"txt":"мультибайтовый "}`,
 	}
 	for i := range validInputs {

--- a/server/drafty/drafty_test.go
+++ b/server/drafty/drafty_test.go
@@ -6,6 +6,11 @@ import (
 )
 
 var validInputs = []string{
+	`"This is a plain text string."`,
+	`{
+		"txt":"This is a string with a line break.",
+		"fmt":[{"at":9,"tp":"BR"}]
+	}`,
 	`{
 		"ent":[{"data":{"mime":"image/jpeg","name":"hello.jpg","val":"<38992, bytes: ...>","width":100, "height":80},"tp":"EX"}],
 		"fmt":[{"at":-1, "key":0}]
@@ -78,6 +83,8 @@ var invalidInputs = []string{
 
 func TestToPlainText(t *testing.T) {
 	expect := []string{
+		"This is a plain text string.",
+		"This is a\n string with a line break.",
 		"[FILE 'hello.jpg']",
 		"[https://api.tinode.co/](https://www.youtube.com/watch?v=dQw4w9WgXcQ)",
 		"https://api.tinode.co/",
@@ -116,6 +123,8 @@ func TestToPlainText(t *testing.T) {
 
 func TestPreview(t *testing.T) {
 	expect := []string{
+		`{"txt":"This is a plain"}`,
+		`{"txt":"This is a strin","fmt":[{"at":9,"tp":"BR"}]}`,
 		`{"fmt":[{"at":-1}],"ent":[{"tp":"EX","data":{"height":80,"mime":"image/jpeg","name":"hello.jpg","width":100}}]}`,
 		`{"txt":"https://api.tin","fmt":[{"len":15}],"ent":[{"tp":"LN","data":{"url":"https://www.youtube.com/watch?v=dQw4w9WgXcQ"}}]}`,
 		`{"txt":"https://api.tin","fmt":[{"len":15}],"ent":[{"tp":"LN","data":{"url":"https://api.tinode.co/"}}]}`,

--- a/server/push/fcm/payload.go
+++ b/server/push/fcm/payload.go
@@ -153,7 +153,7 @@ func payloadToData(pl *push.Payload) (map[string]string, error) {
 		data["mime"] = pl.ContentType
 
 		// Convert Drafty content to plain text (clients 0.16 and below).
-		data["content"], err = drafty.ToPlainText(pl.Content)
+		data["content"], err = drafty.PlainText(pl.Content)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Drafty formatting refactored to use trees: a doc is converted to a tree where each node is uniformly formatted, like

[_quick **fox** jumps_ over] ->
```
[[EM: quick, [ST: fox], jumps], over]
```
It simplified removal of quoted text, shortening etc. Also added a few more tests for various corner cases.

--

There are three unrelated changes:
* `auth_basic.go`: added '**.**' as a permitted character to logins: https://groups.google.com/g/tinode/c/Ncl0MG-QzQM/m/cvi88V0ACAAJ
* Added a comment to mysql `schema.sql` as a reaction to this: https://groups.google.com/g/tinode/c/meEqSq6XzKU/m/tzGrao6-CAAJ
* Fixed a bug in `store.go` related to handling of out-of-band uploaded files.