### PR TITLE
Possible fix for a crash

### DIFF
--- a/server/cluster.go
+++ b/server/cluster.go
@@ -1123,7 +1123,7 @@ func (sess *Session) clusterWriteLoop(forTopic string) {
 		if terminate {
 			sess.closeRPC()
 			globals.sessionStore.Delete(sess)
-			// FIXME: maybe sess.inflightReqs = nil
+			sess.inflightReqs = nil
 			sess.unsubAll()
 		}
 	}()

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -1123,6 +1123,7 @@ func (sess *Session) clusterWriteLoop(forTopic string) {
 		if terminate {
 			sess.closeRPC()
 			globals.sessionStore.Delete(sess)
+			// FIXME: maybe sess.inflightReqs = nil
 			sess.unsubAll()
 		}
 	}()

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -1061,7 +1061,7 @@ func (c *Cluster) invalidateProxySubs(forNode string) {
 	globals.hub.topics.Range(func(_, v interface{}) bool {
 		topic := v.(*Topic)
 		if !topic.isProxy {
-			// Topic either isn't a proxy.
+			// Topic isn't a proxy.
 			return true
 		}
 		if forNode == "" {

--- a/server/init_topic.go
+++ b/server/init_topic.go
@@ -79,8 +79,10 @@ func topicInit(t *Topic, join *ClientComMessage, h *Hub) {
 		}
 		for len(t.unreg) > 0 {
 			msg := <-t.unreg
+			if msg.sess.inflightReqs != nil {
+				msg.sess.inflightReqs.Done()
+			}
 			if msg.init {
-				// FIXME: do we need to call msg.sess.inflightReqs.Done()?
 				msg.sess.queueOut(ErrLockedReply(msg, timestamp))
 			}
 		}

--- a/server/init_topic.go
+++ b/server/init_topic.go
@@ -80,6 +80,7 @@ func topicInit(t *Topic, join *ClientComMessage, h *Hub) {
 		for len(t.unreg) > 0 {
 			msg := <-t.unreg
 			if msg.init {
+				// FIXME: do we need to call msg.sess.inflightReqs.Done()?
 				msg.sess.queueOut(ErrLockedReply(msg, timestamp))
 			}
 		}

--- a/server/init_topic.go
+++ b/server/init_topic.go
@@ -79,7 +79,7 @@ func topicInit(t *Topic, join *ClientComMessage, h *Hub) {
 		}
 		for len(t.unreg) > 0 {
 			msg := <-t.unreg
-			if msg.sess.inflightReqs != nil {
+			if msg.sess != nil && msg.sess.inflightReqs != nil {
 				msg.sess.inflightReqs.Done()
 			}
 			if msg.init {

--- a/server/session.go
+++ b/server/session.go
@@ -228,7 +228,6 @@ func (s *Session) unsubAll() {
 	for _, sub := range s.subs {
 		// sub.done is the same as topic.unreg
 		// The whole session is being dropped.
-		// FIXME: do I need to call s.inflightReqs.Add(1) or set s.inflightReqs = nil.
 		sub.done <- &ClientComMessage{sess: s}
 	}
 }
@@ -413,7 +412,7 @@ func (s *Session) cleanUp(expired bool) {
 	atomic.StoreInt32(&s.terminating, 1)
 	s.purgeChannels()
 	s.inflightReqs.Wait()
-	// FIXME: maybe sess.inflightReqs = nil as it no longer used after Wait().
+	s.inflightReqs = nil
 	if !expired {
 		s.sessionStoreLock.Lock()
 		globals.sessionStore.Delete(s)

--- a/server/session.go
+++ b/server/session.go
@@ -228,6 +228,7 @@ func (s *Session) unsubAll() {
 	for _, sub := range s.subs {
 		// sub.done is the same as topic.unreg
 		// The whole session is being dropped.
+		// FIXME: do I need to call s.inflightReqs.Add(1)?
 		sub.done <- &ClientComMessage{sess: s}
 	}
 }

--- a/server/session.go
+++ b/server/session.go
@@ -228,7 +228,7 @@ func (s *Session) unsubAll() {
 	for _, sub := range s.subs {
 		// sub.done is the same as topic.unreg
 		// The whole session is being dropped.
-		// FIXME: do I need to call s.inflightReqs.Add(1)?
+		// FIXME: do I need to call s.inflightReqs.Add(1) or set s.inflightReqs = nil.
 		sub.done <- &ClientComMessage{sess: s}
 	}
 }
@@ -413,6 +413,7 @@ func (s *Session) cleanUp(expired bool) {
 	atomic.StoreInt32(&s.terminating, 1)
 	s.purgeChannels()
 	s.inflightReqs.Wait()
+	// FIXME: maybe sess.inflightReqs = nil as it no longer used after Wait().
 	if !expired {
 		s.sessionStoreLock.Lock()
 		globals.sessionStore.Delete(s)

--- a/server/topic_proxy.go
+++ b/server/topic_proxy.go
@@ -135,7 +135,7 @@ func (t *Topic) handleProxyLeaveRequest(msg *ClientComMessage, killTimer *time.T
 	}
 
 	if err := globals.cluster.routeToTopicMaster(ProxyReqLeave, msg, t.name, msg.sess); err != nil {
-		logs.Warn.Println("proxy topic: route broadcast request from proxy to master failed:", err)
+		logs.Warn.Println("proxy topic: route leave request from proxy to master failed:", err)
 	}
 	if len(t.sessions) == 0 {
 		// No more sessions attached. Start the countdown.


### PR DESCRIPTION
```
I2021/11/19 13:10:13 in: '{"sub":{"id":"95264","topic":"fnd","get":{"what":"sub"}}}' sid='RxIw50I5tpQ' uid='PFAQXh91150'
W2021/11/19 13:10:13 cluster: call failed tinode-2 unexpected EOF
W2021/11/19 13:10:13 proxy topic: route sess update request from proxy to master failed: unexpected EOF
I2021/11/19 13:10:14 cluster: connected to tinode-2
panic: sync: negative WaitGroup counter

goroutine 36840 [running]:
sync.(*WaitGroup).Add(0xc000480300, 0xc0004ce1a0)
	/usr/local/go/src/sync/waitgroup.go:74 +0x105
sync.(*WaitGroup).Done(...)
	/usr/local/go/src/sync/waitgroup.go:99
main.(*Topic).runProxy(0xc000480300, 0xc000cb9950)
	/Users/gene/go/src/github.com/tinode/chat/server/topic_proxy.go:41 +0x636
main.(*Topic).run(0xc0003fdad0, 0xc000cb9950)
	/Users/gene/go/src/github.com/tinode/chat/server/topic.go:208 +0x25
created by main.topicInit
	/Users/gene/go/src/github.com/tinode/chat/server/init_topic.go:128 +0x82f
```