### PR TITLE
delete minor unreachable code caused by t.Fatal

### DIFF
--- a/server/topic_test.go
+++ b/server/topic_test.go
@@ -179,7 +179,6 @@ func (h *Hub) testHubLoop(t *testing.T, results map[string][]*ServerComMessage, 
 	for msg := range h.routeSrv {
 		if msg.RcptTo == "" {
 			t.Fatal("Hub.route received a message without addressee.")
-			break
 		}
 		results[msg.RcptTo] = append(results[msg.RcptTo], msg)
 	}


### PR DESCRIPTION
Signed-off-by: Abirdcfly <fp544037857@gmail.com>

https://pkg.go.dev/testing#T.Fatal 
> Fatal is equivalent to Log followed by FailNow.

so `break` will not run.