### PR TITLE
Add chn multiplexing sessions to topic master.

### DIFF
--- a/server/topic.go
+++ b/server/topic.go
@@ -3615,7 +3615,7 @@ func (t *Topic) addSession(sess *Session, asUid types.Uid, isChanSub bool) {
 		if sess.background {
 			t.sessions[s] = perSessionData{}
 		} else {
-			t.sessions[s] = perSessionData{muids: []types.Uid{asUid}}
+			t.sessions[s] = perSessionData{muids: []types.Uid{asUid}, isChanSub: isChanSub}
 		}
 	} else {
 		t.sessions[s] = perSessionData{uid: asUid, isChanSub: isChanSub}


### PR DESCRIPTION
Multiplexing sessions are currently attached to topic masters with `isChanSub` set to false.
This leads to errors in handling channel requests routed from proxies.

Solution:
For channel topics, add two multiplexing sessions depending on request type: regular "grpXXX-node" and "chnXXX-node" with `isChanSub` set to true.