### PR TITLE
More correct handling of channel topics in cluster mode

### DIFF
--- a/server/cluster.go
+++ b/server/cluster.go
@@ -824,9 +824,10 @@ func (c *Cluster) routeToTopicMaster(reqType ProxyReqType, msg *ClientComMessage
 		// Cluster may be nil due to shutdown.
 		return nil
 	}
-	if sess != nil {
+	if sess != nil && reqType != ProxyReqLeave {
 		if atomic.LoadInt32(&sess.terminating) > 0 {
 			// The session is terminating.
+			// Do not forward any requests except "leave" to the topic master.
 			return nil
 		}
 	}

--- a/server/pres.go
+++ b/server/pres.go
@@ -400,7 +400,7 @@ func (t *Topic) presSubsOnlineDirect(what string, params *presParams, filter *pr
 			// For p2p topics topic name is dependent on receiver.
 			// It's OK to change the pointer here because the message will be serialized in queueOut
 			// before being placed into the channel.
-			t.maybeFixTopicName(msg, pssd.uid, pssd.isChanSub)
+			t.prepareBroadcastableMessage(msg, pssd.uid, pssd.isChanSub)
 		}
 		s.queueOut(msg)
 	}

--- a/server/pres.go
+++ b/server/pres.go
@@ -400,7 +400,7 @@ func (t *Topic) presSubsOnlineDirect(what string, params *presParams, filter *pr
 			// For p2p topics topic name is dependent on receiver.
 			// It's OK to change the pointer here because the message will be serialized in queueOut
 			// before being placed into the channel.
-			t.maybeFixTopicName(msg, pssd.uid)
+			t.maybeFixTopicName(msg, pssd.uid, pssd.isChanSub)
 		}
 		s.queueOut(msg)
 	}

--- a/server/topic_proxy.go
+++ b/server/topic_proxy.go
@@ -141,13 +141,11 @@ func (t *Topic) handleProxyLeaveRequest(msg *ClientComMessage, killTimer *time.T
 	if msg.Original == "" {
 		if t.cat == types.TopicCatGrp && t.isChan {
 			// It's a channel topic. Original topic name depends the subscription type.
-			var toriginal string
 			if result && pssd.isChanSub {
-				toriginal = types.GrpToChn(t.xoriginal)
+				msg.Original = types.GrpToChn(t.xoriginal)
 			} else {
-				toriginal = t.xoriginal
+				msg.Original = t.xoriginal
 			}
-			msg.Original = toriginal
 		} else {
 			msg.Original = t.original(asUid)
 		}

--- a/server/topic_proxy.go
+++ b/server/topic_proxy.go
@@ -129,13 +129,28 @@ func (t *Topic) handleProxyLeaveRequest(msg *ClientComMessage, killTimer *time.T
 	// Remove the session from the topic without waiting for a response from the master node
 	// because by the time the response arrives this session may be already gone from the session store
 	// and we won't be able to find and remove it by its sid.
-	_, result := t.remSession(msg.sess, asUid)
+	pssd, result := t.remSession(msg.sess, asUid)
 	if !msg.init {
 		// Explicitly specify the uid because the master multiplex session needs to know which
 		// of its multiple hosted sessions to delete.
 		msg.AsUser = asUid.UserId()
 		msg.Leave = &MsgClientLeave{}
 		msg.init = true
+	}
+	// Make sure we set the Original field if it's empty (e.g. when session is terminating altogether).
+	if msg.Original == "" {
+		if t.cat == types.TopicCatGrp && t.isChan {
+			// It's a channel topic. Original topic name depends the subscription type.
+			var toriginal string
+			if result && pssd.isChanSub {
+				toriginal = types.GrpToChn(t.xoriginal)
+			} else {
+				toriginal = t.xoriginal
+			}
+			msg.Original = toriginal
+		} else {
+			msg.Original = t.original(asUid)
+		}
 	}
 
 	if err := globals.cluster.routeToTopicMaster(ProxyReqLeave, msg, t.name, msg.sess); err != nil {


### PR DESCRIPTION
Errors fixed:
1. When both `chnX` and `grpX` multiplexing sessions (for the same channel topic) are attached to topic master, send messages to only `grpX`.
2. When rewriting topic name for the client (`Topic.maybeFixTopicName()`) take subscription type (channel/non-channel) into account.
3. Set `Original` field in the `leave` messages from topic proxy to master so the master can process these requests correctly.