### PR TITLE
Remove deadlock on server overload, #786

### DIFF
--- a/server/cluster.go
+++ b/server/cluster.go
@@ -20,10 +20,18 @@ import (
 )
 
 const (
+	// Network connection timeout.
+	clusterNetworkTimeout = 3 * time.Second
 	// Default timeout before attempting to reconnect to a node.
-	defaultClusterReconnect = 200 * time.Millisecond
+	clusterDefaultReconnectTime = 200 * time.Millisecond
 	// Number of replicas in ringhash.
 	clusterHashReplicas = 20
+	// Buffer size for sending requests from proxy to master.
+	clusterProxyToMasterBuffer = 64
+	// Buffer size for master to proxy answers, per node.
+	clusterMasterToProxyBuffer = 64
+	// Buffer size for receiving responses from other nodes, per node.
+	clusterRpcCompletionBuffer = 64
 )
 
 // ProxyReqType is the type of proxy requests.
@@ -77,19 +85,36 @@ type ClusterNode struct {
 	// A number of times this node has failed in a row
 	failCount int
 
-	// Channel for shutting down the runner; buffered, 1
+	// Channel for shutting down the runner; buffered, 1.
 	done chan bool
 
 	// IDs of multiplexing sessions belonging to this node.
 	msess map[string]struct{}
 
 	// Default channel for receiving responses to RPC calls issued by this node.
+	// Buffered, clusterRpcCompletionBuffer * number_of_nodes.
 	rpcDone chan *rpc.Call
+
+	// Channel for sending proxy to master requests; buffered, clusterProxyToMasterBuffer.
+	p2mSender chan *ClusterReq
 }
 
 func (n *ClusterNode) asyncRpcLoop() {
 	for call := range n.rpcDone {
 		n.handleRpcResponse(call)
+	}
+}
+
+func (n *ClusterNode) p2mSenderLoop() {
+	for req := range n.p2mSender {
+		if req == nil {
+			// Stop
+			return
+		}
+
+		if err := n.proxyToMaster(req); err != nil {
+			logs.Warn.Println("p2mSenderLoop: call failed", n.name, err)
+		}
 	}
 }
 
@@ -231,14 +256,14 @@ func (n *ClusterNode) reconnect() {
 	n.lock.Unlock()
 
 	count := 0
-	var err error
 	for {
 		// Attempt to reconnect right away
-		if n.endpoint, err = rpc.Dial("tcp", n.address); err == nil {
+		if conn, err := net.DialTimeout("tcp", n.address, clusterNetworkTimeout); err == nil {
 			if reconnTicker != nil {
 				reconnTicker.Stop()
 			}
 			n.lock.Lock()
+			n.endpoint = rpc.NewClient(conn)
 			n.connected = true
 			n.reconnecting = false
 			n.lock.Unlock()
@@ -254,7 +279,7 @@ func (n *ClusterNode) reconnect() {
 				&unused)
 			return
 		} else if count == 0 {
-			reconnTicker = time.NewTicker(defaultClusterReconnect)
+			reconnTicker = time.NewTicker(clusterDefaultReconnectTime)
 		}
 
 		count++
@@ -364,6 +389,16 @@ func (n *ClusterNode) proxyToMaster(msg *ClusterReq) error {
 		err = errors.New("cluster: topic master node out of sync")
 	}
 	return err
+}
+
+// proxyToMaster forwards request from topic proxy to topic master.
+func (n *ClusterNode) proxyToMasterAsync(msg *ClusterReq) error {
+	select {
+	case n.p2mSender <- msg:
+		return nil
+	default:
+		return errors.New("cluster: load exceeded")
+	}
 }
 
 // masterToProxyAsync forwards response from topic master to topic proxy
@@ -584,27 +619,32 @@ func (Cluster) TopicProxy(msg *ClusterResp, unused *bool) error {
 // Route endpoint receives intra-cluster messages destined for the nodes hosting the topic.
 // Called by Hub.route channel consumer for messages send without attaching to topic first.
 func (c *Cluster) Route(msg *ClusterRoute, rejected *bool) error {
+	logError := func(err string) {
+		sid := ""
+		if msg.Sess != nil {
+			sid = msg.Sess.Sid
+		}
+		logs.Warn.Println(err, sid)
+		*rejected = true
+	}
+
 	*rejected = false
 	if msg.Signature != c.ring.Signature() {
-		sid := ""
-		if msg.Sess != nil {
-			sid = msg.Sess.Sid
-		}
-		logs.Warn.Println("cluster Route: session signature mismatch", sid)
-		*rejected = true
+		logError("cluster Route: session signature mismatch")
 		return nil
 	}
+
 	if msg.SrvMsg == nil {
-		sid := ""
-		if msg.Sess != nil {
-			sid = msg.Sess.Sid
-		}
 		// TODO: maybe panic here.
-		logs.Warn.Println("cluster Route: nil server message", sid)
-		*rejected = true
+		logError("cluster Route: nil server message")
 		return nil
 	}
-	globals.hub.routeSrv <- msg.SrvMsg
+
+	select {
+	case globals.hub.routeSrv <- msg.SrvMsg:
+	default:
+		logError("cluster Route: server busy")
+	}
 	return nil
 }
 
@@ -824,6 +864,7 @@ func (c *Cluster) routeToTopicMaster(reqType ProxyReqType, msg *ClientComMessage
 		// Cluster may be nil due to shutdown.
 		return nil
 	}
+
 	if sess != nil && reqType != ProxyReqLeave {
 		if atomic.LoadInt32(&sess.terminating) > 0 {
 			// The session is terminating.
@@ -832,13 +873,13 @@ func (c *Cluster) routeToTopicMaster(reqType ProxyReqType, msg *ClientComMessage
 		}
 	}
 
+	req := c.makeClusterReq(reqType, msg, topic, sess)
+
 	// Find the cluster node which owns the topic, then forward to it.
 	n := c.nodeForTopic(topic)
 	if n == nil {
 		return errors.New("node for topic not found")
 	}
-
-	req := c.makeClusterReq(reqType, msg, topic, sess)
 	return n.proxyToMaster(req)
 }
 
@@ -997,8 +1038,10 @@ func (c *Cluster) start() {
 
 	for _, n := range c.nodes {
 		go n.reconnect()
-		n.rpcDone = make(chan *rpc.Call, len(c.nodes)*50)
+		n.rpcDone = make(chan *rpc.Call, len(c.nodes)*clusterRpcCompletionBuffer)
+		n.p2mSender = make(chan *ClusterReq, clusterProxyToMasterBuffer)
 		go n.asyncRpcLoop()
+		go n.p2mSenderLoop()
 	}
 
 	if c.fo != nil {
@@ -1022,6 +1065,7 @@ func (c *Cluster) shutdown() {
 	}
 	for _, n := range c.nodes {
 		close(n.rpcDone)
+		close(n.p2mSender)
 	}
 
 	globals.cluster.proxyEventQueue.Stop()

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -880,7 +880,7 @@ func (c *Cluster) routeToTopicMaster(reqType ProxyReqType, msg *ClientComMessage
 	if n == nil {
 		return errors.New("node for topic not found")
 	}
-	return n.proxyToMaster(req)
+	return n.proxyToMasterAsync(req)
 }
 
 // Forward server response message to the node that owns topic.
@@ -923,7 +923,7 @@ func (c *Cluster) topicProxyGone(topicName string) error {
 
 	req := c.makeClusterReq(ProxyReqLeave, nil, topicName, nil)
 	req.Gone = true
-	return n.proxyToMaster(req)
+	return n.proxyToMasterAsync(req)
 }
 
 // Returns snowflake worker id.

--- a/server/datamodel.go
+++ b/server/datamodel.go
@@ -1625,27 +1625,34 @@ func ErrNotImplementedReply(msg *ClientComMessage, ts time.Time) *ServerComMessa
 	return ErrNotImplemented(msg.Id, msg.Original, ts, msg.Timestamp)
 }
 
-// ErrClusterUnreachable in-cluster communication has failed (502).
-func ErrClusterUnreachable(id, topic string, ts time.Time) *ServerComMessage {
+// ErrClusterUnreachableReply in-cluster communication has failed error as response to a client request (502).
+func ErrClusterUnreachableReply(msg *ClientComMessage, ts time.Time) *ServerComMessage {
+	return ErrClusterUnreachableExplicitTs(msg.Id, msg.Original, ts, msg.Timestamp)
+}
+
+// ErrClusterUnreachable in-cluster communication has failed error with explicit server and
+// incoming request timestamps (502).
+func ErrClusterUnreachableExplicitTs(id, topic string, serverTs, incomingReqTs time.Time) *ServerComMessage {
 	return &ServerComMessage{
 		Ctrl: &MsgServerCtrl{
 			Id:        id,
 			Code:      http.StatusBadGateway, // 502
 			Text:      "cluster unreachable",
 			Topic:     topic,
-			Timestamp: ts,
+			Timestamp: serverTs,
 		},
 		Id:        id,
-		Timestamp: ts,
+		Timestamp: incomingReqTs,
 	}
 }
 
-// ErrServiceUnavailableReply server error in response to a client request (503).
+// ErrServiceUnavailableReply server overloaded error in response to a client request (503).
 func ErrServiceUnavailableReply(msg *ClientComMessage, ts time.Time) *ServerComMessage {
 	return ErrServiceUnavailableExplicitTs(msg.Id, msg.Original, ts, msg.Timestamp)
 }
 
-// ErrServiceUnavailableExplicitTs server error (503).
+// ErrServiceUnavailableExplicitTs server overloaded error with explicit server and
+// incoming request timestamps (503).
 func ErrServiceUnavailableExplicitTs(id, topic string, serverTs, incomingReqTs time.Time) *ServerComMessage {
 	return &ServerComMessage{
 		Ctrl: &MsgServerCtrl{

--- a/server/run-cluster.sh
+++ b/server/run-cluster.sh
@@ -11,6 +11,9 @@ GRPC_BASE_PORT=16060
 
 USAGE="Usage: $0 [ --config <path_to_tinode.conf> ] {start|stop}"
 
+# Your server binary may have a different name and location.
+SERVER='./server'
+
 if [ "$#" -lt "1" ]; then
   echo $USAGE
   exit 1
@@ -48,7 +51,7 @@ while [[ $# -gt 0 ]]; do
       for NODE_NAME in "${ALL_NODE_NAMES[@]}"
       do
         # Start the node
-        ./server -config=${TINODE_CONF} -cluster_self=${NODE_NAME} -listen=:${HTTP_PORT} -grpc_listen=:${GRPC_PORT} -static_data=${STATIC_DATA_DIR} -log_flags=stdFlags,shortfile &
+        $SERVER -config=${TINODE_CONF} -cluster_self=${NODE_NAME} -listen=:${HTTP_PORT} -grpc_listen=:${GRPC_PORT} -static_data=${STATIC_DATA_DIR} -log_flags=stdFlags,shortfile &
         # Save PID of the node to a temp file.
         # /var/tmp/ does not requre root access.
         echo $!> "/var/tmp/tinode-${NODE_NAME}.pid"

--- a/server/session.go
+++ b/server/session.go
@@ -595,7 +595,7 @@ func (s *Session) dispatch(msg *ClientComMessage) {
 	if globals.cluster.isPartitioned() {
 		// The cluster is partitioned due to network or other failure and this node is a part of the smaller partition.
 		// In order to avoid data inconsistency across the cluster we must reject all requests.
-		s.queueOut(ErrClusterUnreachable(msg.Id, msg.Original, msg.Timestamp))
+		s.queueOut(ErrClusterUnreachableReply(msg, msg.Timestamp))
 		return
 	}
 


### PR DESCRIPTION
1. Added a network connection timeout when connecting to nodes.
2. Added a channel+goroutine and a check for overload for RPC calls from Proxy to Master. Proxy topic sends a message to clients if RCP call to master failed. 
3. Added a check for overload when master node sends requests to master's hub.

What I don't like here is that when the master rejects a call from the proxy, the error is just logged by the `p2mSenderLoop`, while it should be reported back to the calling session. It's highly unlikely that this would happen in production because the buffer cluster->hub at master is much bigger than the buffer at proxy->master. But still.