### PR TITLE
Fix Bug: When Init-DB by json file, ignore tags of user if defined (Issue #795)

### DIFF
--- a/tinode-db/gendb.go
+++ b/tinode-db/gendb.go
@@ -52,7 +52,6 @@ func genDb(data *Data) {
 		}
 		user.CreatedAt = getCreatedTime(uu.CreatedAt)
 
-		user.Tags = make([]string, 0)
 		user.Tags = append(user.Tags, "basic:"+uu.Username)
 		if uu.Email != "" {
 			user.Tags = append(user.Tags, "email:"+uu.Email)


### PR DESCRIPTION
When use `./init-db -data=mydata.json`, It seems that the program ignores the input tags. #795 

I dont programmer of *GO* but I think that is fixed. *Please review it*