### PR TITLE
fix: add quotes to str in tn-cli : encode_to_bytes

### DIFF
--- a/tn-cli/tn-cli.py
+++ b/tn-cli/tn-cli.py
@@ -202,7 +202,7 @@ def encode_to_bytes(src):
     if src == None:
         return None
     if isinstance(src, str):
-        return src.encode('utf-8')
+        return ('"' + src + '"').encode()
     return json.dumps(src).encode('utf-8')
 
 # Parse credentials


### PR DESCRIPTION
Fixes "resolve" and "pub" commands in CLI.

Examples of wrong behaviour before fix:

**pub**:
![image](https://user-images.githubusercontent.com/14962059/219972802-9424a0a9-e8cd-482a-82c2-f8c5d1fd94ba.png)

**resolve**:
![image](https://user-images.githubusercontent.com/14962059/219972834-ac79b635-3d4a-4c41-a63f-32eb9e05b0c1.png)
