### PR TITLE
Fix online status of unchanged online connections

### DIFF
--- a/server/store/types/types.go
+++ b/server/store/types/types.go
@@ -923,6 +923,9 @@ type Subscription struct {
 
 	// Topic's or user's state.
 	state ObjState
+
+	// This is not a fully initialized subscription object
+	dummy bool
 }
 
 // SetPublic assigns a value to `public`, otherwise not accessible from outside the package.
@@ -1031,6 +1034,16 @@ func (s *Subscription) GetState() ObjState {
 // SetState assigns topic's or user's state.
 func (s *Subscription) SetState(state ObjState) {
 	s.state = state
+}
+
+// SetDummy marks this subscription object as only partially intialized.
+func (s *Subscription) SetDummy(dummy bool) {
+	s.dummy = dummy
+}
+
+// IsDummy is true if this subscription object as only partially intialized.
+func (s *Subscription) IsDummy() bool {
+	return s.dummy
 }
 
 // Contact is a result of a search for connections

--- a/server/topic.go
+++ b/server/topic.go
@@ -2368,7 +2368,7 @@ func (t *Topic) replyGetSub(sess *Session, asUid types.Uid, authLevel auth.Level
 			// User manages cache. Include deleted subscriptions too.
 			subs, err = store.Users.GetTopicsAny(asUid, msgOpts2storeOpts(req))
 
-			// Returned subscriptions does not load topics which are online now but otherwise unchanged.
+			// Returned subscriptions do not contain topics which are online now but otherwise unchanged.
 			// We need to add these topic to the list otherwise the user would see them as offline.
 			selected := map[string]struct{}{}
 			for i := range subs {


### PR DESCRIPTION
Fixes the following bug:

1. Bob is online (does not matter how).
2. Alice is online from both web and Android. Alice sees Bob as online, everything is fine.
3. Alice disconnects Android, then reconnects, web stays connected. Now Alice sees Bob as offline on Android.
