### PR TITLE
Fix a race condition around Session.subs.

### DIFF
--- a/loadtest/tinode.scala
+++ b/loadtest/tinode.scala
@@ -29,7 +29,7 @@ class TinodeBase extends Simulation {
   val hello = exitBlockOnFail {
     exec {
       ws("hi").sendText(
-        """{"hi":{"id":"afabb3","ver":"0.18.1","ua":"Gatling-Loadtest/1.0; gatling/1.7.0"}}"""
+        """{"hi":{"id":"afabb3","ver":"0.22.8","ua":"Gatling-Loadtest/1.0; gatling/1.7.0"}}"""
       )
       .await(15 seconds)(
         ws.checkTextMessage("hi")

--- a/server/session.go
+++ b/server/session.go
@@ -118,7 +118,7 @@ type Session struct {
 	bkgTimer *time.Timer
 
 	// Number of subscribe/unsubscribe requests in flight.
-	inflightReqs *sync.WaitGroup
+	inflightReqs *boundedWaitGroup
 	// Synchronizes access to session store in cluster mode:
 	// subscribe/unsubscribe replies are asynchronous.
 	sessionStoreLock sync.Mutex
@@ -629,11 +629,12 @@ func (s *Session) subscribe(msg *ClientComMessage) {
 		}
 	}
 
+	s.inflightReqs.Add(1)
 	// Session can subscribe to topic on behalf of a single user at a time.
 	if sub := s.getSub(msg.RcptTo); sub != nil {
 		s.queueOut(InfoAlreadySubscribed(msg.Id, msg.Original, msg.Timestamp))
+		s.inflightReqs.Done()
 	} else {
-		s.inflightReqs.Add(1)
 		select {
 		case globals.hub.join <- msg:
 		default:
@@ -656,18 +657,21 @@ func (s *Session) leave(msg *ClientComMessage) {
 		return
 	}
 
+	s.inflightReqs.Add(1)
 	if sub := s.getSub(msg.RcptTo); sub != nil {
 		// Session is attached to the topic.
 		if (msg.Original == "me" || msg.Original == "fnd") && msg.Leave.Unsub {
 			// User should not unsubscribe from 'me' or 'find'. Just leaving is fine.
 			s.queueOut(ErrPermissionDeniedReply(msg, msg.Timestamp))
+			s.inflightReqs.Done()
 		} else {
 			// Unlink from topic, topic will send a reply.
-			s.delSub(msg.RcptTo)
-			s.inflightReqs.Add(1)
 			sub.done <- msg
 		}
-	} else if !msg.Leave.Unsub {
+		return
+	}
+	s.inflightReqs.Done()
+	if !msg.Leave.Unsub {
 		// Session is not attached to the topic, wants to leave - fine, no change
 		s.queueOut(InfoNotJoined(msg.Id, msg.Original, msg.Timestamp))
 	} else {

--- a/server/topic.go
+++ b/server/topic.go
@@ -740,6 +740,9 @@ func (t *Topic) handleLeaveRequest(msg *ClientComMessage, sess *Session) {
 
 	// User wants to leave without unsubscribing.
 	if pssd, _ := t.remSession(sess, asUid); pssd != nil {
+		if !sess.isProxy() {
+			sess.detach <- t.name
+		}
 		if pssd.isChanSub != asChan {
 			// Cannot address non-channel subscription as channel and vice versa.
 			if msg.init {

--- a/server/topic_proxy.go
+++ b/server/topic_proxy.go
@@ -138,6 +138,9 @@ func (t *Topic) handleProxyLeaveRequest(msg *ClientComMessage, killTimer *time.T
 	// because by the time the response arrives this session may be already gone from the session store
 	// and we won't be able to find and remove it by its sid.
 	pssd, result := t.remSession(msg.sess, asUid)
+	if result {
+		msg.sess.detach <- t.name
+	}
 	if !msg.init {
 		// Explicitly specify the uid because the master multiplex session needs to know which
 		// of its multiple hosted sessions to delete.


### PR DESCRIPTION
1. Session.addSub & Session.delSub should be happening (atomically) together modifications of Topic.sessions.
2. Only one of Session.subscribe() and Session.leave() is allowed to be inflight at any given moment.

Attempt at addressing https://github.com/tinode/chat/issues/866