### PR TITLE
Fix a race condition around Session.subs.

### DIFF
--- a/loadtest/tinode.scala
+++ b/loadtest/tinode.scala
@@ -29,7 +29,7 @@ class TinodeBase extends Simulation {
   val hello = exitBlockOnFail {
     exec {
       ws("hi").sendText(
-        """{"hi":{"id":"afabb3","ver":"0.18.1","ua":"Gatling-Loadtest/1.0; gatling/1.7.0"}}"""
+        """{"hi":{"id":"afabb3","ver":"0.22.8","ua":"Gatling-Loadtest/1.0; gatling/1.7.0"}}"""
       )
       .await(15 seconds)(
         ws.checkTextMessage("hi")

--- a/server/topic.go
+++ b/server/topic.go
@@ -720,7 +720,7 @@ func (t *Topic) handleLeaveRequest(msg *ClientComMessage, sess *Session) {
 	// User wants to leave without unsubscribing.
 	if pssd, _ := t.remSession(sess, asUid); pssd != nil {
 		if !sess.isProxy() {
-			sess.detach <- t.name
+			sess.delSub(t.name)
 		}
 		if pssd.isChanSub != asChan {
 			// Cannot address non-channel subscription as channel and vice versa.

--- a/server/topic.go
+++ b/server/topic.go
@@ -719,6 +719,9 @@ func (t *Topic) handleLeaveRequest(msg *ClientComMessage, sess *Session) {
 
 	// User wants to leave without unsubscribing.
 	if pssd, _ := t.remSession(sess, asUid); pssd != nil {
+		if !sess.isProxy() {
+			sess.detach <- t.name
+		}
 		if pssd.isChanSub != asChan {
 			// Cannot address non-channel subscription as channel and vice versa.
 			if msg.init {

--- a/server/topic_proxy.go
+++ b/server/topic_proxy.go
@@ -139,7 +139,7 @@ func (t *Topic) handleProxyLeaveRequest(msg *ClientComMessage, killTimer *time.T
 	// and we won't be able to find and remove it by its sid.
 	pssd, result := t.remSession(msg.sess, asUid)
 	if result {
-		msg.sess.detach <- t.name
+		msg.sess.delSub(t.name)
 	}
 	if !msg.init {
 		// Explicitly specify the uid because the master multiplex session needs to know which

--- a/server/topic_proxy.go
+++ b/server/topic_proxy.go
@@ -138,6 +138,9 @@ func (t *Topic) handleProxyLeaveRequest(msg *ClientComMessage, killTimer *time.T
 	// because by the time the response arrives this session may be already gone from the session store
 	// and we won't be able to find and remove it by its sid.
 	pssd, result := t.remSession(msg.sess, asUid)
+	if result {
+		msg.sess.detach <- t.name
+	}
 	if !msg.init {
 		// Explicitly specify the uid because the master multiplex session needs to know which
 		// of its multiple hosted sessions to delete.


### PR DESCRIPTION
1. Session.addSub & Session.delSub should be happening (atomically) together modifications of Topic.sessions.
2. Only one of Session.subscribe() and Session.leave() is allowed to be inflight at any given moment.

Attempt at addressing https://github.com/tinode/chat/issues/866