### PR TITLE
CORS headers in upload file API for all types of requests

### DIFF
--- a/server/media/media.go
+++ b/server/media/media.go
@@ -98,11 +98,6 @@ func matchCORSMethod(allowMethods []string, method string) bool {
 
 // CORSHandler is the default preflight OPTIONS processor for use by media handlers.
 func CORSHandler(req *http.Request, allowedOrigins []string, serve bool) (http.Header, int) {
-	if req.Method != http.MethodOptions {
-		// Not an OPTIONS request. No special handling for all other requests.
-		return nil, 0
-	}
-
 	var allowMethods []string
 	if serve {
 		allowMethods = []string{http.MethodGet, http.MethodHead, http.MethodOptions}

--- a/server/media/s3/s3.go
+++ b/server/media/s3/s3.go
@@ -151,12 +151,8 @@ func (ah *awshandler) Init(jsconf string) error {
 	return err
 }
 
-// Headers redirects GET, HEAD requests to the AWS server.
+// Headers redirects to the AWS server.
 func (ah *awshandler) Headers(req *http.Request, serve bool) (http.Header, int, error) {
-	if req.Method == http.MethodPut || req.Method == http.MethodPost {
-		return nil, 0, nil
-	}
-
 	if headers, status := media.CORSHandler(req, ah.conf.CorsOrigins, serve); status != 0 {
 		return headers, status, nil
 	}


### PR DESCRIPTION
There is a problem. If you host the backend and frontend on different domains and try to upload a file using the /v0/file/u/ API, you get the error: “Access to XMLHttpRequest at ‘https://backend/v0/file/u/’ from origin ‘https://frontend’ has been blocked by CORS policy: No ‘Access-Control-Allow-Origin’ header is present on the requested resource.”
This is happening because the Tinode chat server adds Access-Control-Allow-* headers only for OPTIONS requests, but not for POST. This scheme could have worked only if the POST request were a simple request, but in the POST request, we add custom headers such as X-Tinode-Apikey, X-Tinode-Auth, and it becomes not simple :)
So if our POST request isn’t a simple request, we have to add Access-Control-Allow-* headers also in OPTIONS and POST responses.

Examples in the attachments.
![Screenshot 2024-04-05 at 22 21 28](https://github.com/tinode/chat/assets/18211389/0779c3d7-70ba-44b9-bbd1-281c2979a66a)
![Screenshot 2024-04-05 at 22 22 33](https://github.com/tinode/chat/assets/18211389/e97c5b75-34eb-435c-aff9-dbcaa70a307b)
