### PR TITLE
Fix botUID in chatbot

### DIFF
--- a/chatbot/python/.gitignore
+++ b/chatbot/python/.gitignore
@@ -1,0 +1,1 @@
+.tn-cookie

--- a/chatbot/python/chatbot.py
+++ b/chatbot/python/chatbot.py
@@ -301,6 +301,7 @@ def read_auth_cookie(cookie_file_name):
     return schema, secret
 
 def on_login(cookie_file_name, params):
+    global botUID
     client_post(subscribe('me'))
 
     """Save authentication token to file"""
@@ -308,7 +309,7 @@ def on_login(cookie_file_name, params):
         return
 
     if 'user' in params:
-        botUID = params['user'].decode("ascii")
+        botUID = params['user'].decode("ascii")[1:-1]
 
     # Protobuf map 'params' is not a python object or dictionary. Convert it.
     nice = {'schema': 'token'}


### PR DESCRIPTION
Hi,

Thanks for your great project. I am working on deploying Tinode and developing chatbots. The `botUID` in the current chatbot example does not work because it is always `None`. So this PR fixes it.

By the way, I can help build a unified Python API for both chatbot and tn-cli, based on the code of tn-cli. What is your opinion on this? Thank you!