### PR TITLE
chore/add ssl mode for postgres adapter

### DIFF
--- a/server/tinode.conf
+++ b/server/tinode.conf
@@ -261,6 +261,7 @@
 				"Host": "localhost",
 				"Port": "5432",
 				"DBName": "tinode",
+				"SSLMode": "disable",
 
 				// DSN: alternative way of specifying database configuration, passed unchanged
 				// to the driver. See https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING


### PR DESCRIPTION
- server: updated the tinode conf
- server/db/postgres: put default value