### PR TITLE
chore/add new index for sql optimizations

### DIFF
--- a/server/db/mysql/schema.sql
+++ b/server/db/mysql/schema.sql
@@ -232,3 +232,9 @@ CREATE TABLE filemsglinks(
 	FOREIGN KEY(topicid) REFERENCES topics(id) ON DELETE CASCADE,
 	FOREIGN KEY(userid) REFERENCES users(id) ON DELETE CASCADE
 );
+
+# Find relevant subscriptions for given users efficiently, and use the join key too.
+CREATE INDEX idx_subs_user_topic_del ON subscriptions(userid, topic, deletedat);
+
+# Optimizes join; state filters; seqid supports the SUM operation.
+CREATE INDEX idx_topics_name_state_seqid ON topics(name, state, seqid);

--- a/server/db/postgres/adapter.go
+++ b/server/db/postgres/adapter.go
@@ -47,7 +47,7 @@ type adapter struct {
 }
 
 const (
-	adpVersion  = 114
+	adpVersion  = 115
 	adapterName = "postgres"
 
 	defaultMaxResults = 1024
@@ -576,6 +576,16 @@ func (a *adapter) CreateDb(reset bool) error {
 		return err
 	}
 
+	// Find relevant subscriptions for given users efficiently, and use the join key too.
+	if _, err = tx.Exec(ctx, "CREATE INDEX idx_subs_user_topic_del ON subscriptions(userid, topic, deletedat)"); err != nil {
+		return err
+	}
+
+	// Optimizes join; state filters; seqid supports the SUM operation.
+	if _, err = tx.Exec(ctx, "CREATE INDEX idx_topics_name_state_seqid ON topics(name, state, seqid)"); err != nil {
+		return err
+	}
+
 	return tx.Commit(ctx)
 }
 
@@ -642,6 +652,24 @@ func (a *adapter) UpgradeDb() error {
 		}
 
 		if err := bumpVersion(a, 114); err != nil {
+			return err
+		}
+	}
+
+	if a.version == 114 {
+		// Perform database upgrade from version 114 to version 115.
+
+		// Find relevant subscriptions for given users efficiently, and use the join key too.
+		if _, err := a.db.Exec(ctx, "CREATE INDEX idx_subs_user_topic_del ON subscriptions(userid, topic, deletedat)"); err != nil {
+			return err
+		}
+
+		// Optimizes join; state filters; seqid supports the SUM operation.
+		if _, err := a.db.Exec(ctx, "CREATE INDEX idx_topics_name_state_seqid ON topics(name, state, seqid)"); err != nil {
+			return err
+		}
+
+		if err := bumpVersion(a, 115); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
- server/db/mysql: implemented version 115
- server/db/postgres: implemented version 115
- optimized the join for state filters and seqid
- optimized the search for relevant subscription

while load testing the postgres adpater, I found out that the CPU Usage is reaching ~100%
<img width="1629" alt="Screenshot 2025-06-16 at 20 28 26" src="https://github.com/user-attachments/assets/32fec288-83e3-4a73-a87a-f7d90b5187dc" />
we optimized this by finding doing an RCA and traced it  back to a query that reaches 2.5 second which is the function  **UserUnreadCount** 
After implementing the indexes, we ran the load test again and found significant improvements. 
<img width="1092" alt="Screenshot 2025-06-18 at 13 10 13" src="https://github.com/user-attachments/assets/d634939a-fb58-4b1f-971a-a5a46560575a" />

Test config: : 1 TPS | 30 min | 5000 customers and 5000 drivers as test data

Message flow: 
- Customer will login
- Cusomer will create a groupchat and add driver1 and driver2 to the chat
- Customer1 will publish first message
- Driver1 will login and publish second message
- Driver2 will login and publish third message

EXPLAIN QUERY RESULTS
Before
`GroupAggregate  (cost=2751.50..2751.53 rows=1 width=16)`
After
`GroupAggregate  (cost=0.70..83.51 rows=1 width=16)`