### PR TITLE
fix/return found on FindOne function

### DIFF
--- a/server/db/postgres/adapter.go
+++ b/server/db/postgres/adapter.go
@@ -2415,6 +2415,7 @@ func (a *adapter) FindOne(tag string) (string, error) {
 		// User IDs are returned as decoded decimal strings.
 		if id, err := strconv.ParseInt(found, 10, 64); err == nil {
 			found = store.EncodeUid(id).UserId()
+			return found, nil
 		}
 	}
 


### PR DESCRIPTION
Currently, testing a process on postgres adapter. Saw that this function doesnt return anything. 

Updated the function to return the search results.