### PR TITLE
perf(push/tnpg): reduce allocations in postMessage with sync.Pool

### DIFF
--- a/server/push/tnpg/push_tnpg.go
+++ b/server/push/tnpg/push_tnpg.go
@@ -36,14 +36,14 @@ var handler Handler
 const maxPooledPostBodyCap = 1 << 16
 
 var postBodyPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return new(bytes.Buffer)
 	},
 }
 
 var gzipWriterPool = sync.Pool{
-	New: func() interface{} {
-		return gzip.NewWriter(io.Discard)
+	New: func() any {
+		return gzip.NewWriter(nil)
 	},
 }
 
@@ -169,7 +169,7 @@ func (Handler) Init(jsonconf json.RawMessage) (bool, error) {
 	return true, nil
 }
 
-func postMessage(endpoint string, body interface{}, config *configType) (*batchResponse, error) {
+func postMessage(endpoint string, body any, config *configType) (*batchResponse, error) {
 	buf := postBodyPool.Get().(*bytes.Buffer)
 	defer func() {
 		buf.Reset()
@@ -181,7 +181,7 @@ func postMessage(endpoint string, body interface{}, config *configType) (*batchR
 
 	gzw := gzipWriterPool.Get().(*gzip.Writer)
 	defer func() {
-		gzw.Reset(io.Discard)
+		gzw.Reset(nil)
 		gzipWriterPool.Put(gzw)
 	}()
 	gzw.Reset(buf)

--- a/server/push/tnpg/push_tnpg.go
+++ b/server/push/tnpg/push_tnpg.go
@@ -171,7 +171,6 @@ func (Handler) Init(jsonconf json.RawMessage) (bool, error) {
 
 func postMessage(endpoint string, body interface{}, config *configType) (*batchResponse, error) {
 	buf := postBodyPool.Get().(*bytes.Buffer)
-	buf.Reset()
 	defer func() {
 		buf.Reset()
 		if cap(buf.Bytes()) > maxPooledPostBodyCap {
@@ -181,12 +180,15 @@ func postMessage(endpoint string, body interface{}, config *configType) (*batchR
 	}()
 
 	gzw := gzipWriterPool.Get().(*gzip.Writer)
+	defer func() {
+		gzw.Reset(io.Discard)
+		gzipWriterPool.Put(gzw)
+	}()
 	gzw.Reset(buf)
 	err := json.NewEncoder(gzw).Encode(body)
 	if closeErr := gzw.Close(); err == nil {
 		err = closeErr
 	}
-	gzipWriterPool.Put(gzw)
 	if err != nil {
 		return nil, err
 	}

--- a/server/push/tnpg/push_tnpg.go
+++ b/server/push/tnpg/push_tnpg.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 
 	"github.com/tinode/chat/server/logs"
 	"github.com/tinode/chat/server/push"
@@ -31,6 +32,20 @@ const (
 )
 
 var handler Handler
+
+const maxPooledPostBodyCap = 1 << 16
+
+var postBodyPool = sync.Pool{
+	New: func() interface{} {
+		return new(bytes.Buffer)
+	},
+}
+
+var gzipWriterPool = sync.Pool{
+	New: func() interface{} {
+		return gzip.NewWriter(io.Discard)
+	},
+}
 
 // Handler represents state of TNPG push client.
 type Handler struct {
@@ -154,11 +169,24 @@ func (Handler) Init(jsonconf json.RawMessage) (bool, error) {
 	return true, nil
 }
 
-func postMessage(endpoint string, body any, config *configType) (*batchResponse, error) {
-	buf := new(bytes.Buffer)
-	gzw := gzip.NewWriter(buf)
+func postMessage(endpoint string, body interface{}, config *configType) (*batchResponse, error) {
+	buf := postBodyPool.Get().(*bytes.Buffer)
+	buf.Reset()
+	defer func() {
+		buf.Reset()
+		if cap(buf.Bytes()) > maxPooledPostBodyCap {
+			return
+		}
+		postBodyPool.Put(buf)
+	}()
+
+	gzw := gzipWriterPool.Get().(*gzip.Writer)
+	gzw.Reset(buf)
 	err := json.NewEncoder(gzw).Encode(body)
-	gzw.Close()
+	if closeErr := gzw.Close(); err == nil {
+		err = closeErr
+	}
+	gzipWriterPool.Put(gzw)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- In server/push/tnpg/push_tnpg.go (postMessage), reuse *bytes.Buffer and *gzip.Writer via sync.Pool to reduce per-request allocations and GC pressure.
- Buffers are reset on reuse, and very large buffers are not kept in the pool to avoid memory bloat.
- Fixes #987